### PR TITLE
docs: Add security disclaimer and responsible disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,6 @@ The `--tmp` flag creates temporary storage for blockchain data, but network keys
 | Phase 3 – Deployment   | H2 2026 onward   | White-label deployments • Central-bank oracle integrations • Multi-jurisdiction operations |
 
 Contact: helloclad@wideas.tech
+
+> **Disclaimer**  
+> Clad Sovereign is pre-pilot software. It is not yet intended for production use or real fund issuance. Use only on testnets or local chains.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+Clad Sovereign is pre-pilot software intended for sovereign issuers.
+
+## Reporting a Vulnerability
+
+Please **do not** open public issues for security vulnerabilities.
+
+Email security issues to: helloclad@wideas.tech
+
+We will acknowledge receipt within 48 hours and provide updates on resolution.
+
+Thank you for helping keep Clad Sovereign and its future users safe.


### PR DESCRIPTION
## Summary
- Add pre-pilot disclaimer to README clarifying project is not production-ready
- Add SECURITY.md with responsible disclosure guidelines for security researchers
- Improve transparency about project maturity level

## Changes
- **README.md**: Added disclaimer section noting pre-pilot status and testnet-only usage
- **SECURITY.md**: New file with security reporting instructions and contact information

## Rationale
As the project prepares for grant applications and early demos, it's important to clearly communicate that this is pre-production software. This protects both the project and potential users by setting appropriate expectations.