### PR TITLE
docs: Clarify Components table to avoid grant milestone confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Primary reference: Paraguay sovereign equity tokenization (2025).
 
 ## Components
 
-| Component                  | Status          | Description |
-|----------------------------|-----------------|-------------|
-| `pallet-clad-token`        | ✅ Complete (MVP)  | FRAME pallet with roles, freeze/unfreeze, whitelist, ERC-3643-compatible hooks. Extensible for voting rights and repayment oracles. |
-| `clad-node`                | ✅ Complete (Milestone 2) | Substrate node with Aura consensus and Grandpa finality. Complete runtime integration with operational RPC endpoints. |
-| `clad-mobile`              | 🚧 In Development | Kotlin Multiplatform native signer (iOS/Android) with biometric authentication and offline QR signing. Production delivery: Feb 2026. |
+| Component           | Repository | Status | Description |
+|---------------------|------------|--------|-------------|
+| `pallet-clad-token` | [clad-studio](https://github.com/clad-sovereign/clad-studio) | ✅ Functional | FRAME pallet with roles, freeze/unfreeze, whitelist, ERC-3643-compatible hooks. Production hardening in progress. |
+| `clad-node`         | [clad-studio](https://github.com/clad-sovereign/clad-studio) | ✅ Functional | Substrate node with Aura consensus and Grandpa finality. Enables local multi-validator testnet. |
+| `clad-signer`       | [clad-mobile](https://github.com/clad-sovereign/clad-mobile) | 🚧 In Development | Kotlin Multiplatform native signer (iOS/Android) with biometric authentication and offline QR signing. |
 
 ## Target Markets
 


### PR DESCRIPTION
## Summary

- Add Repository column with links to respective repos
- Change status labels from "Complete (MVP/Milestone 2)" to "Functional"
- Rename `clad-mobile` to `clad-signer` to match actual app name
- Remove milestone references that could conflict with grant terminology
- Simplify descriptions and remove timeline details (covered in Roadmap)

## Rationale

The previous Components table used "(Milestone 2)" for `clad-node`, which could confuse grant reviewers since our Polkadot Open Source Grant has only 2 milestones:
- **Grant Milestone 1**: Pallet production hardening
- **Grant Milestone 2**: Mobile signing infrastructure

Neither grant milestone references `clad-node`. This change removes ambiguous milestone terminology and presents a cleaner status overview.

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] Confirm links to repositories are valid