### PR TITLE
feat(runtime): integrate pallet-multisig for N-of-M admin governance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,7 @@ dependencies = [
  "pallet-balances",
  "pallet-clad-token",
  "pallet-grandpa",
+ "pallet-multisig",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -6313,6 +6314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-multisig"
+version = "43.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2509-2#7304752b47858f2cd601b35d0eb734ad4ccbbc48"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-session"
 version = "43.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2509-2#7304752b47858f2cd601b35d0eb734ad4ccbbc48"
@@ -7527,7 +7539,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -7564,9 +7576,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8039,7 +8051,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,6 +17,7 @@ frame-system-rpc-runtime-api = { default-features = false, git = "https://github
 pallet-aura = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-grandpa = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
+pallet-multisig = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
@@ -57,6 +58,7 @@ std = [
     "pallet-aura/std",
     "pallet-balances/std",
     "pallet-grandpa/std",
+    "pallet-multisig/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment/std",
@@ -83,6 +85,7 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
     "pallet-grandpa/runtime-benchmarks",
+    "pallet-multisig/runtime-benchmarks",
     "pallet-sudo/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-transaction-payment/runtime-benchmarks",


### PR DESCRIPTION
## Summary

Integrates `pallet-multisig` from the Polkadot SDK into the runtime to enable multi-signature approval flows for admin operations.

## Motivation

> "No government will use single-key admin control"

Finance ministries require multiple officials to approve sensitive operations like minting $50M+ bond tokens. This PR adds the infrastructure for N-of-M threshold signing.

## Changes

- Added `pallet-multisig` dependency to `runtime/Cargo.toml`
- Configured `pallet_multisig::Config` in `runtime/src/lib.rs`:
  - `DepositBase`: 1 unit (reserved when creating multi-sig operation)
  - `DepositFactor`: 0.1 unit per signatory
  - `MaxSignatories`: 10 (accommodates ministry committees)
  - `BlockNumberProvider`: `frame_system::Pallet<Runtime>`
- Added `Multisig` to `construct_runtime!` macro

## What This Enables

```
Ministry Officials (5 phones, 5 mnemonics)
    │
    ▼
Multi-sig Account (3-of-5 threshold)
    │
    ▼
AdminOrigin for pallet-clad-token
```

## Test Plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --locked -- -D warnings` passes  
- [x] `cargo test --locked` passes (57 tests)
- [x] `cargo build --release -p clad-runtime` succeeds

## Follow-up Work

- #33 — Integration tests for multi-sig admin operations
- Configure multi-sig account as `AdminOrigin` (chain spec update)
- Mobile app `GovernanceService` implementation (clad-mobile#72)

## Related

- Closes #32
- [ADR-001: Multi-Sig Governance](docs/adr/001-multi-sig-governance.md)