### PR TITLE
docs(readme): add missing --validator flag to 2-node setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ For rapid testing of basic consensus (Aura block production + Grandpa finality):
 ./target/release/clad-node \
   --chain local \
   --alice \
+  --validator \
   --tmp \
   --port 30333 \
   --rpc-port 9944 \
@@ -141,6 +142,7 @@ For rapid testing of basic consensus (Aura block production + Grandpa finality):
 ./target/release/clad-node \
   --chain local \
   --bob \
+  --validator \
   --tmp \
   --port 30334 \
   --rpc-port 9945 \


### PR DESCRIPTION
## Summary
- Add missing `--validator` flag to both Alice and Bob in the 2-node local testnet setup
- Without this flag, GRANDPA finalization doesn't work and blocks never reach finalized state

## Test plan
- [x] Verified 2-node setup with `--validator` flag reaches finality
- [x] Confirmed `chain_getFinalizedHead` advances (not stuck at genesis)