### PR TITLE
fix(runtime): remove sudo pallet, simplify admin to EnsureStorageAdmin only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,6 @@ dependencies = [
  "pallet-clad-token",
  "pallet-grandpa",
  "pallet-multisig",
- "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6367,21 +6366,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
-]
-
-[[package]]
-name = "pallet-sudo"
-version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2509-2#7304752b47858f2cd601b35d0eb734ad4ccbbc48"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-io",
- "sp-runtime",
 ]
 
 [[package]]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -33,8 +33,8 @@ impl SubstrateCli for Cli {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
-            "dev" => Box::new(chain_spec::development_config()?),
-            "" | "local" => Box::new(chain_spec::local_testnet_config()?),
+            // Single development chain spec - 2 validators, 2-of-3 multi-sig admin
+            "" | "dev" | "local" => Box::new(chain_spec::development_config()?),
             path => {
                 Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
             }

--- a/pallets/clad-token/src/lib.rs
+++ b/pallets/clad-token/src/lib.rs
@@ -1533,8 +1533,9 @@ pub mod pallet {
 
             Decimals::<T>::put(self.decimals);
 
-            // Whitelist admin if provided
+            // Set and whitelist admin if provided
             if let Some(ref admin) = self.admin {
+                Admin::<T>::put(admin);
                 Whitelist::<T>::insert(admin, true);
             }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -18,7 +18,6 @@ pallet-aura = { default-features = false, git = "https://github.com/paritytech/p
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-grandpa = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-multisig = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
-pallet-sudo = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2509-2" }
@@ -59,7 +58,6 @@ std = [
     "pallet-balances/std",
     "pallet-grandpa/std",
     "pallet-multisig/std",
-    "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
@@ -86,7 +84,6 @@ runtime-benchmarks = [
     "pallet-balances/runtime-benchmarks",
     "pallet-grandpa/runtime-benchmarks",
     "pallet-multisig/runtime-benchmarks",
-    "pallet-sudo/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-transaction-payment/runtime-benchmarks",
     "pallet-clad-token/runtime-benchmarks",


### PR DESCRIPTION
## Summary

- Remove pallet-sudo entirely from runtime (no more root bypass)
- Simplify `CladTokenAdminOrigin` from triple-origin to `EnsureStorageAdmin` only
- Consolidate `development_config()` and `local_testnet_config()` into single chain spec
- Fix genesis_build to store admin in storage (was only whitelisting)

## Changes

| File | Change |
|------|--------|
| `runtime/Cargo.toml` | Remove pallet-sudo dependency |
| `runtime/src/lib.rs` | Remove sudo config, simplify admin origin |
| `node/src/chain_spec.rs` | Single chain spec with 2-of-3 multi-sig admin |
| `node/src/command.rs` | Route dev/local to same chain spec |
| `pallets/clad-token/src/lib.rs` | Fix: `Admin::<T>::put(admin)` in genesis_build |
| `runtime/src/tests.rs` | Rewrite for multi-sig governance flow (18 tests) |
| `pallets/clad-token/src/tests.rs` | Update for admin-from-genesis behavior |

## Admin Configuration

- **Dev/Local**: 2-of-3 multi-sig (Alice, Bob, Charlie) → `5DjYJStmdZ2rcqXbXGX7TW85JsrW6uG4y9MUcLq2BoPMpRA7`
- **Production**: Custom chain spec with real multi-sig address

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] `cargo test --locked` (81 tests pass)
- [x] `cargo build --release --locked`

Closes #52