### PR TITLE
feat(signer-core): Phase 2 — port sr25519, ed25519, blake2, ss58, extrinsic encoding

### DIFF
--- a/.github/workflows/signer-core.yml
+++ b/.github/workflows/signer-core.yml
@@ -114,11 +114,7 @@ jobs:
         run: |
           xcodebuild test \
             -scheme SignerCoreSample \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
-            | xcpretty || (xcodebuild test \
-                -scheme SignerCoreSample \
-                -destination 'platform=iOS Simulator,name=iPhone 16 Pro'; exit 1)
-        shell: bash
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
 
       - name: Package xcframework for upload (zip)
         working-directory: crates/signer-core

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9885,12 +9885,18 @@ dependencies = [
 name = "signer-core"
 version = "0.1.0"
 dependencies = [
+ "blake2 0.10.6",
+ "bs58",
+ "ed25519-zebra",
  "hex",
+ "parity-scale-codec",
  "proptest",
+ "schnorrkel",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "uniffi",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/signer-core/Cargo.toml
+++ b/crates/signer-core/Cargo.toml
@@ -28,10 +28,26 @@ default = []
 # Enables the `uniffi-bindgen` binary above. Kept off by default so `cargo build`
 # in the workspace doesn't pull the CLI dependency unnecessarily.
 uniffi-cli = ["uniffi/cli"]
+# Enable std-dependent feature implementations.
+std = [
+    "schnorrkel/std",
+    "ed25519-zebra/std",
+    "parity-scale-codec/std",
+    "blake2/std",
+    "bs58/std",
+    "hex/std",
+]
 
 [dependencies]
 uniffi = { version = "0.28.3" }
 thiserror = "1"
+schnorrkel = { version = "0.11", default-features = false, features = ["alloc"] }
+ed25519-zebra = { version = "4", default-features = false }
+parity-scale-codec = { version = "3", default-features = false, features = ["derive"] }
+blake2 = { version = "0.10", default-features = false }
+bs58 = { version = "0.5", default-features = false, features = ["alloc"] }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [build-dependencies]
 uniffi = { version = "0.28.3", features = ["build"] }
@@ -41,3 +57,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 proptest = "1"
 hex = "0.4"
+# schnorrkel's internal nonce-derivation machinery calls into getrandom even
+# for the deterministic signing path.  The `std` feature makes getrandom
+# available during tests.  Production builds stay no_std (see [dependencies]).
+schnorrkel = { version = "0.11", features = ["std"] }

--- a/crates/signer-core/src/crypto/blake2.rs
+++ b/crates/signer-core/src/crypto/blake2.rs
@@ -1,0 +1,47 @@
+//! Blake2b hashing functions.
+//!
+//! Mirrors `Hasher.kt` — `blake2b256` and `blake2b128` — used by Substrate for:
+//! - Signing payload hashing when payload length ≥ 256 bytes
+//! - Transaction hash computation (extrinsic hash)
+//! - Storage key hashing (`Blake2_128Concat` hasher)
+//!
+//! Uses the [`blake2`] crate which supports `no_std`.
+
+use alloc::vec::Vec;
+
+use blake2::digest::consts::{U16, U32, U64};
+use blake2::{Blake2b, Digest};
+
+/// Compute a 32-byte Blake2b-256 hash of `data`.
+///
+/// Used by Substrate for signing payloads ≥ 256 bytes and as the extrinsic hash.
+pub fn blake2b_256(data: &[u8]) -> Vec<u8> {
+    let mut hasher = Blake2b::<U32>::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}
+
+/// Compute a 16-byte Blake2b-128 hash of `data`.
+///
+/// Used by Substrate for `Blake2_128Concat` storage key hashing.
+pub fn blake2b_128(data: &[u8]) -> Vec<u8> {
+    let mut hasher = Blake2b::<U16>::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}
+
+/// Compute a 64-byte Blake2b-512 hash of `data`.
+pub fn blake2b_512(data: &[u8]) -> Vec<u8> {
+    let mut hasher = Blake2b::<U64>::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}
+
+/// Compute `blake2b_128(data) || data` — the `Blake2_128Concat` storage hasher.
+///
+/// Used for storage maps where the key must be recoverable from the hash.
+pub fn blake2b_128_concat(data: &[u8]) -> Vec<u8> {
+    let mut result = blake2b_128(data);
+    result.extend_from_slice(data);
+    result
+}

--- a/crates/signer-core/src/crypto/ed25519.rs
+++ b/crates/signer-core/src/crypto/ed25519.rs
@@ -1,0 +1,53 @@
+//! ED25519 signing and verification.
+//!
+//! Wraps [`ed25519_zebra`] which is `no_std + alloc` compatible.
+//!
+//! # Wire format
+//! - Signing key (seed): 32 bytes (RFC 8032 private seed)
+//! - Verification key (public key): 32 bytes
+//! - Signature: 64 bytes
+
+use alloc::vec::Vec;
+
+use ed25519_zebra::{SigningKey, VerificationKey};
+
+use super::CryptoError;
+
+/// Sign `message` with the ED25519 signing key encoded as a 32-byte seed.
+///
+/// The signature is deterministic (RFC 8032 §5.1).
+pub fn sign(message: &[u8], seed: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    if seed.len() != 32 {
+        return Err(CryptoError::InvalidSecretKey);
+    }
+    let seed_arr: [u8; 32] = seed.try_into().map_err(|_| CryptoError::InvalidSecretKey)?;
+    let sk = SigningKey::from(seed_arr);
+    let sig: ed25519_zebra::Signature = sk.sign(message);
+    Ok(<[u8; 64]>::from(sig).to_vec())
+}
+
+/// Verify a 64-byte ED25519 `signature` over `message` against `public_key`.
+pub fn verify(message: &[u8], signature: &[u8], public_key: &[u8]) -> bool {
+    let Ok(pk_arr): Result<[u8; 32], _> = public_key.try_into() else {
+        return false;
+    };
+    let Ok(vk) = VerificationKey::try_from(pk_arr) else {
+        return false;
+    };
+    let Ok(sig_arr): Result<[u8; 64], _> = signature.try_into() else {
+        return false;
+    };
+    let sig = ed25519_zebra::Signature::from(sig_arr);
+    vk.verify(&sig, message).is_ok()
+}
+
+/// Derive the 32-byte ED25519 public key (verification key) from a 32-byte seed.
+pub fn public_key_from_seed(seed: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    if seed.len() != 32 {
+        return Err(CryptoError::InvalidSecretKey);
+    }
+    let seed_arr: [u8; 32] = seed.try_into().map_err(|_| CryptoError::InvalidSecretKey)?;
+    let sk = SigningKey::from(seed_arr);
+    let vk = VerificationKey::from(&sk);
+    Ok(<[u8; 32]>::from(vk).to_vec())
+}

--- a/crates/signer-core/src/crypto/mod.rs
+++ b/crates/signer-core/src/crypto/mod.rs
@@ -1,0 +1,40 @@
+//! Cryptographic primitives for the Clad Sovereign signer.
+//!
+//! All modules in this tree are `no_std + alloc` compatible and mirror the
+//! Kotlin oracle implementations in `clad-mobile/shared/`:
+//! - [`sr25519`] ← `crypto/Signer.kt` (SR25519 path)
+//! - [`ed25519`] ← `crypto/Signer.kt` (ED25519 path)
+//! - [`blake2`]  ← `crypto/Hasher.kt`
+//! - [`ss58`]    ← `crypto/Ss58.kt`
+//!
+//! `CryptoError` is a flat error enum exposed through the UniFFI boundary.
+
+pub mod blake2;
+pub mod ed25519;
+pub mod sr25519;
+pub mod ss58;
+
+use thiserror::Error;
+
+/// Errors produced by cryptographic operations exposed at the FFI boundary.
+///
+/// Flat enum — no nested `Result<Result<…>>` shapes per ADR-007.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CryptoError {
+    #[error("invalid secret key bytes")]
+    InvalidSecretKey,
+    #[error("invalid public key bytes")]
+    InvalidPublicKey,
+    #[error("invalid signature bytes")]
+    InvalidSignature,
+    #[error("invalid SS58 address")]
+    InvalidAddress,
+    #[error("invalid SS58 prefix")]
+    InvalidPrefix,
+    #[error("invalid or unsupported metadata")]
+    InvalidMetadata,
+    #[error("unknown pallet")]
+    UnknownPallet,
+    #[error("unknown call")]
+    UnknownCall,
+}

--- a/crates/signer-core/src/crypto/sr25519.rs
+++ b/crates/signer-core/src/crypto/sr25519.rs
@@ -1,0 +1,122 @@
+//! SR25519 signing and verification.
+//!
+//! Wraps [`schnorrkel`] to provide the same interface as the Kotlin oracle
+//! `Signer.kt` (platform implementations: Nova Substrate SDK on Android,
+//! NovaCrypto on iOS).
+//!
+//! # Signing mode
+//!
+//! **Production** uses `Keypair::sign_simple` with an OS-supplied random nonce
+//! (non-deterministic).  Test-only deterministic signing is available via
+//! [`sign_deterministic`] which uses a fixed synthetic nonce derived from the
+//! message; do **not** use it in production.
+//!
+//! # Wire format
+//! - Secret key (seed): 32 bytes (mini-secret / seed)
+//! - Public key: 32 bytes (compressed Ristretto point)
+//! - Signature: 64 bytes
+
+use alloc::vec::Vec;
+
+use schnorrkel::{signing_context, ExpansionMode, MiniSecretKey, PublicKey, Signature};
+
+use super::CryptoError;
+
+/// Signing context label used by Substrate / polkadot-sdk.
+///
+/// Source: `sp_core::sr25519` — `SR25519_SIGNING_CTX = b"substrate"`.
+const SIGNING_CTX: &[u8] = b"substrate";
+
+// ── Key derivation ────────────────────────────────────────────────────────────
+
+/// Derive the 32-byte SR25519 public key from a 32-byte seed (mini-secret).
+pub fn public_key_from_seed(seed: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let mini = MiniSecretKey::from_bytes(seed).map_err(|_| CryptoError::InvalidSecretKey)?;
+    let keypair = mini.expand_to_keypair(ExpansionMode::Ed25519);
+    Ok(keypair.public.to_bytes().to_vec())
+}
+
+// ── Signing ───────────────────────────────────────────────────────────────────
+
+/// Sign `message` using the SR25519 secret key encoded as a 32-byte seed.
+///
+/// Uses `sign_simple` with a random nonce (non-deterministic in production).
+/// The returned signature is 64 bytes.
+pub fn sign(message: &[u8], seed: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let mini = MiniSecretKey::from_bytes(seed).map_err(|_| CryptoError::InvalidSecretKey)?;
+    let keypair = mini.expand_to_keypair(ExpansionMode::Ed25519);
+    let context = signing_context(SIGNING_CTX);
+    let sig = keypair.sign(context.bytes(message));
+    Ok(sig.to_bytes().to_vec())
+}
+
+/// **Test-only** SR25519 signing via `SecretKey::sign`.
+///
+/// Calls schnorrkel's `SecretKey::sign` which mixes the expanded key's `nonce`
+/// field into the merlin transcript before the randomness squeeze.  Despite the
+/// "deterministic" naming inherited from earlier design docs, this function is
+/// **NOT** byte-stable — merlin's `witness_rng` additionally calls `OsRng` for
+/// each invocation.  It is useful for sign → verify roundtrip tests and as the
+/// future hook for KAT fixtures once byte-stable vectors can be sourced from
+/// the Kotlin oracle (Phase 2b).
+///
+/// **Do not call from production code.**
+#[cfg(test)]
+pub fn sign_deterministic(message: &[u8], seed: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    // schnorrkel does not expose a built-in deterministic path for sign_simple.
+    // We derive a stable nonce seed by hashing (seed || message) with blake2b-256
+    // and use it to feed the keypair's nonce RNG via sign_simple with a
+    // `SecretKey::sign_simple_doublehasher` workaround.
+    //
+    // For KAT purposes the simplest approach that gives byte-stability across
+    // runs is to just call `sign` (which does use the OS RNG) but override the
+    // nonce material by constructing the nonce from the message digest.
+    // schnorrkel 0.11 exposes `SecretKey::sign_simple` which is what we use here.
+    let mini = MiniSecretKey::from_bytes(seed).map_err(|_| CryptoError::InvalidSecretKey)?;
+    let secret = mini.expand(ExpansionMode::Ed25519);
+    let public = mini.expand_to_keypair(ExpansionMode::Ed25519).public;
+    let context = signing_context(SIGNING_CTX);
+    let sig = secret.sign(context.bytes(message), &public);
+    Ok(sig.to_bytes().to_vec())
+}
+
+// ── Verification ──────────────────────────────────────────────────────────────
+
+/// Verify a 64-byte SR25519 `signature` over `message` against `public_key`.
+///
+/// Returns `true` on success, `false` on any verification failure (does not
+/// distinguish bad-key from bad-sig to avoid oracle attacks).
+pub fn verify(message: &[u8], signature: &[u8], public_key: &[u8]) -> bool {
+    let Ok(pk) = PublicKey::from_bytes(public_key) else {
+        return false;
+    };
+    let Ok(sig) = Signature::from_bytes(signature) else {
+        return false;
+    };
+    let context = signing_context(SIGNING_CTX);
+    pk.verify(context.bytes(message), &sig).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sign + verify roundtrip.  Uses `sign_deterministic` (SecretKey::sign path)
+    /// which — like `sign` — requires OS RNG via schnorrkel/merlin internals.
+    /// Byte-stable KAT vectors are deferred to Phase 2b (Kotlin oracle extraction).
+    #[test]
+    fn sign_verify_roundtrip() {
+        let seed = [0x42u8; 32];
+        let message = b"clad-sovereign phase-2 sr25519 roundtrip";
+
+        let sig = sign_deterministic(message, &seed).expect("sign_deterministic failed");
+        assert_eq!(sig.len(), 64, "signature must be 64 bytes");
+
+        let pubkey = public_key_from_seed(&seed).expect("public_key_from_seed failed");
+        assert_eq!(pubkey.len(), 32, "public key must be 32 bytes");
+
+        assert!(verify(message, &sig, &pubkey), "verify failed for own signature");
+        assert!(!verify(b"wrong message", &sig, &pubkey), "verify must reject wrong message");
+        assert!(!verify(message, &sig, &[0u8; 32]), "verify must reject wrong public key");
+    }
+}

--- a/crates/signer-core/src/crypto/ss58.rs
+++ b/crates/signer-core/src/crypto/ss58.rs
@@ -1,0 +1,157 @@
+//! SS58 address encoding and decoding.
+//!
+//! Mirrors `Ss58.kt` — `encode(publicKey, networkPrefix)` / `decode(address)`.
+//!
+//! # SS58 wire format
+//!
+//! ```text
+//! base58_encode( prefix_bytes || public_key(32) || checksum(2) )
+//! ```
+//!
+//! where:
+//! - `prefix_bytes` encodes the network prefix (u16) using the Substrate
+//!   "canary" scheme:
+//!   - prefix 0–63  → 1 byte: the prefix value itself
+//!   - prefix 64–16383 → 2 bytes: the canary encoding described below
+//! - `checksum` is the first 2 bytes of `blake2b_512("SS58PRE" || payload)`
+//!
+//! Substrate canary 2-byte prefix encoding (prefixes 64–16383):
+//! ```text
+//! raw = prefix
+//! b0  = ((raw & 0xFC) >> 2) | 0x40   -- bits 7..2 of raw (shifted), OR'd with 0x40
+//! b1  = (raw >> 8) | ((raw & 0x03) << 6)  -- high bits + low 2 bits
+//! bytes = [b0, b1]
+//! ```
+//!
+//! References:
+//! - https://docs.substrate.io/reference/address-formats/
+//! - https://github.com/paritytech/ss58-registry
+//! - Substrate `sp_core::crypto::Ss58Codec` (polkadot-sdk)
+
+use alloc::{string::String, vec::Vec};
+
+use super::CryptoError;
+use crate::crypto::blake2::blake2b_512;
+
+/// The SS58 checksum prefix string.
+const SS58_PREFIX: &[u8] = b"SS58PRE";
+
+// ── Encoding ──────────────────────────────────────────────────────────────────
+
+/// Encode a 32-byte `public_key` as an SS58 address with the given `prefix`.
+///
+/// `prefix` must be in 0–16383.  Use 42 for the generic Substrate network
+/// (matching `NetworkPrefix.GENERIC_SUBSTRATE` and `NetworkPrefix.CLAD` in
+/// `Ss58.kt` and `NetworkPrefix.kt`).
+pub fn encode(public_key: &[u8], prefix: u16) -> Result<String, CryptoError> {
+    if public_key.len() != 32 {
+        return Err(CryptoError::InvalidPublicKey);
+    }
+    if prefix > 16383 {
+        return Err(CryptoError::InvalidPrefix);
+    }
+
+    let prefix_bytes = encode_prefix(prefix);
+    let mut payload = prefix_bytes;
+    payload.extend_from_slice(public_key);
+
+    let checksum = ss58_checksum(&payload);
+    payload.extend_from_slice(&checksum[..2]);
+
+    Ok(bs58::encode(payload).into_string())
+}
+
+/// Decode an SS58 `address` into `(public_key_32_bytes, prefix)`.
+pub fn decode(address: &str) -> Result<(Vec<u8>, u16), CryptoError> {
+    let raw = bs58::decode(address).into_vec().map_err(|_| CryptoError::InvalidAddress)?;
+
+    if raw.len() < 35 {
+        return Err(CryptoError::InvalidAddress);
+    }
+
+    let (prefix, offset) = decode_prefix(&raw)?;
+
+    // payload without checksum
+    let payload_end = raw.len() - 2;
+    if payload_end < offset {
+        return Err(CryptoError::InvalidAddress);
+    }
+    let public_key = raw[offset..payload_end].to_vec();
+    if public_key.len() != 32 {
+        return Err(CryptoError::InvalidAddress);
+    }
+
+    // verify checksum
+    let expected_checksum = ss58_checksum(&raw[..payload_end]);
+    if raw[payload_end..] != expected_checksum[..2] {
+        return Err(CryptoError::InvalidAddress);
+    }
+
+    Ok((public_key, prefix))
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn encode_prefix(prefix: u16) -> Vec<u8> {
+    if prefix < 64 {
+        vec![prefix as u8]
+    } else {
+        // Canary 2-byte encoding for prefixes 64–16383.
+        let b0 = (((prefix & 0xFC) >> 2) as u8) | 0x40;
+        let b1 = ((prefix >> 8) as u8) | (((prefix & 0x03) << 6) as u8);
+        vec![b0, b1]
+    }
+}
+
+fn decode_prefix(raw: &[u8]) -> Result<(u16, usize), CryptoError> {
+    if raw.is_empty() {
+        return Err(CryptoError::InvalidAddress);
+    }
+    let b0 = raw[0];
+    if b0 < 64 {
+        Ok((b0 as u16, 1))
+    } else if b0 < 128 {
+        if raw.len() < 2 {
+            return Err(CryptoError::InvalidAddress);
+        }
+        let b1 = raw[1];
+        // Reverse of encode_prefix canary encoding:
+        // b0 = ((raw & 0xFC) >> 2) | 0x40  →  raw_low = (b0 & 0x3F) << 2
+        // b1 = (raw >> 8) | ((raw & 0x03) << 6)  →  raw_high = b1 & 0x3F, raw_bits01 = b1 >> 6
+        let full = (((b0 & 0x3F) as u16) << 2) | ((b1 as u16) >> 6) | ((b1 as u16 & 0x3F) << 8);
+        Ok((full, 2))
+    } else {
+        Err(CryptoError::InvalidPrefix)
+    }
+}
+
+fn ss58_checksum(payload: &[u8]) -> Vec<u8> {
+    let mut data = Vec::with_capacity(SS58_PREFIX.len() + payload.len());
+    data.extend_from_slice(SS58_PREFIX);
+    data.extend_from_slice(payload);
+    blake2b_512(&data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Alice's well-known seed and SS58 address (generic Substrate prefix 42).
+    ///
+    /// Seed:    0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+    /// SS58:    5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+    ///
+    /// Cross-checked against polkadot-js/apps and Substrate's own test suite.
+    #[test]
+    fn alice_ss58_roundtrip() {
+        let pubkey =
+            hex::decode("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")
+                .unwrap();
+        let addr = encode(&pubkey, 42).unwrap();
+        assert_eq!(addr, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+
+        let (decoded_pk, decoded_prefix) = decode(&addr).unwrap();
+        assert_eq!(decoded_pk, pubkey);
+        assert_eq!(decoded_prefix, 42);
+    }
+}

--- a/crates/signer-core/src/extrinsic/call.rs
+++ b/crates/signer-core/src/extrinsic/call.rs
@@ -1,0 +1,248 @@
+//! SCALE-encoded call data builders.
+//!
+//! Mirrors `CladTokenCalls.kt` and `MultisigCalls.kt` 1:1.
+//!
+//! # Wire format per call
+//!
+//! ```text
+//! [pallet_index: u8] [call_index: u8] [params...]
+//! ```
+//!
+//! Params are SCALE-encoded:
+//! - `AccountId`: raw 32 bytes (no prefix — `writeAccountId` in Kotlin)
+//! - `u128 amount`: SCALE Compact<u128>
+//! - `u16 threshold`: little-endian u16
+//! - `Vec<AccountId>`: Compact<len> followed by each AccountId (32 bytes each)
+//! - `Option<Timepoint>`: 0x00 (None) or 0x01 + height(u32 LE) + index(u32 LE)
+//! - `Vec<u8> callData`: Compact<len> followed by bytes
+//! - `Weight`: refTime (Compact<u64>) + proofSize (Compact<u64>)
+//!
+//! # Pallet indices
+//!
+//! - `pallet-clad-token`: index **8** (source: `runtime/src/lib.rs` `construct_runtime!`)
+//! - `pallet-multisig`:   index **7** (source: `MultisigPalletConfig.PALLET_INDEX`)
+
+use alloc::vec::Vec;
+
+use self::scale::{compact_u128, compact_u64, compact_usize};
+
+// Re-export the helper module so tests can use it directly.
+pub(crate) mod scale;
+
+/// An opaque SCALE-encoded call blob.
+pub type CallData = Vec<u8>;
+
+// ── pallet-clad-token ─────────────────────────────────────────────────────────
+
+/// Pallet index for `pallet-clad-token` in the Clad runtime.
+pub const CLAD_TOKEN_PALLET: u8 = 8;
+
+/// Call indices for `pallet-clad-token`.
+pub mod clad_token_call {
+    pub const MINT: u8 = 0;
+    pub const TRANSFER: u8 = 1;
+    pub const FREEZE: u8 = 2;
+    pub const UNFREEZE: u8 = 3;
+    pub const ADD_TO_WHITELIST: u8 = 4;
+    pub const REMOVE_FROM_WHITELIST: u8 = 5;
+    pub const SET_ADMIN: u8 = 6;
+}
+
+/// Build a `mint(to, amount)` call.
+///
+/// `to` must be exactly 32 bytes (AccountId).
+/// `amount` is a SCALE Compact<u128>.
+pub fn mint(to: &[u8], amount: u128) -> CallData {
+    assert_eq!(to.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 32 + 17);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::MINT);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(to);
+    out.extend_from_slice(&compact_u128(amount));
+    out
+}
+
+/// Build a `transfer(to, amount)` call.
+pub fn transfer(to: &[u8], amount: u128) -> CallData {
+    assert_eq!(to.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 33 + 17);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::TRANSFER);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(to);
+    out.extend_from_slice(&compact_u128(amount));
+    out
+}
+
+/// Build a `freeze(account)` call.
+pub fn freeze(account: &[u8]) -> CallData {
+    assert_eq!(account.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 33);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::FREEZE);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(account);
+    out
+}
+
+/// Build an `unfreeze(account)` call.
+pub fn unfreeze(account: &[u8]) -> CallData {
+    assert_eq!(account.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 33);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::UNFREEZE);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(account);
+    out
+}
+
+/// Build an `add_to_whitelist(account)` call.
+pub fn add_to_whitelist(account: &[u8]) -> CallData {
+    assert_eq!(account.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 33);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::ADD_TO_WHITELIST);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(account);
+    out
+}
+
+/// Build a `remove_from_whitelist(account)` call.
+pub fn remove_from_whitelist(account: &[u8]) -> CallData {
+    assert_eq!(account.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 33);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::REMOVE_FROM_WHITELIST);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(account);
+    out
+}
+
+/// Build a `set_admin(new_admin)` call.
+pub fn set_admin(new_admin: &[u8]) -> CallData {
+    assert_eq!(new_admin.len(), 32, "AccountId must be 32 bytes");
+    let mut out = Vec::with_capacity(2 + 33);
+    out.push(CLAD_TOKEN_PALLET);
+    out.push(clad_token_call::SET_ADMIN);
+    out.push(0x00); // MultiAddress::Id prefix
+    out.extend_from_slice(new_admin);
+    out
+}
+
+// ── pallet-multisig ───────────────────────────────────────────────────────────
+
+/// Pallet index for `pallet-multisig` in the Clad runtime.
+pub const MULTISIG_PALLET: u8 = 7;
+
+/// Call indices for `pallet-multisig`.
+pub mod multisig_call {
+    pub const AS_MULTI_THRESHOLD_1: u8 = 0;
+    pub const AS_MULTI: u8 = 1;
+    pub const APPROVE_AS_MULTI: u8 = 2;
+    pub const CANCEL_AS_MULTI: u8 = 3;
+}
+
+/// Build an `as_multi(threshold, other_signatories, maybe_timepoint, call, max_weight)` call.
+///
+/// `other_signatories` must be sorted and must not contain the caller.
+/// `call_data` is the SCALE-encoded inner call (length-prefixed as `Vec<u8>`).
+/// `max_weight` is `(ref_time, proof_size)`.
+pub fn as_multi(
+    threshold: u16,
+    other_signatories: &[&[u8]],
+    maybe_timepoint: Option<(u32, u32)>,
+    call_data: &[u8],
+    max_weight: (u64, u64),
+) -> CallData {
+    let mut out = Vec::new();
+    out.push(MULTISIG_PALLET);
+    out.push(multisig_call::AS_MULTI);
+    // threshold: u16 LE
+    out.extend_from_slice(&threshold.to_le_bytes());
+    // other_signatories: Vec<AccountId>
+    encode_account_id_vec(&mut out, other_signatories);
+    // maybe_timepoint: Option<(block_number: u32, index: u32)>
+    encode_option_timepoint(&mut out, maybe_timepoint);
+    // call: Box<Call> encoded as length-prefixed byte vector
+    out.extend_from_slice(&compact_usize(call_data.len()));
+    out.extend_from_slice(call_data);
+    // max_weight: Weight { ref_time: Compact<u64>, proof_size: Compact<u64> }
+    out.extend_from_slice(&compact_u64(max_weight.0));
+    out.extend_from_slice(&compact_u64(max_weight.1));
+    out
+}
+
+/// Build an `approve_as_multi(threshold, other_signatories, maybe_timepoint, call_hash, max_weight)` call.
+///
+/// `call_hash` must be exactly 32 bytes (Blake2-256 hash of the inner call).
+pub fn approve_as_multi(
+    threshold: u16,
+    other_signatories: &[&[u8]],
+    maybe_timepoint: Option<(u32, u32)>,
+    call_hash: &[u8],
+    max_weight: (u64, u64),
+) -> CallData {
+    assert_eq!(call_hash.len(), 32, "call_hash must be 32 bytes");
+    let mut out = Vec::new();
+    out.push(MULTISIG_PALLET);
+    out.push(multisig_call::APPROVE_AS_MULTI);
+    out.extend_from_slice(&threshold.to_le_bytes());
+    encode_account_id_vec(&mut out, other_signatories);
+    encode_option_timepoint(&mut out, maybe_timepoint);
+    out.extend_from_slice(call_hash); // [u8; 32] — fixed, no length prefix
+    out.extend_from_slice(&compact_u64(max_weight.0));
+    out.extend_from_slice(&compact_u64(max_weight.1));
+    out
+}
+
+/// Build a `cancel_as_multi(threshold, other_signatories, timepoint, call_hash)` call.
+pub fn cancel_as_multi(
+    threshold: u16,
+    other_signatories: &[&[u8]],
+    timepoint: (u32, u32),
+    call_hash: &[u8],
+) -> CallData {
+    assert_eq!(call_hash.len(), 32, "call_hash must be 32 bytes");
+    let mut out = Vec::new();
+    out.push(MULTISIG_PALLET);
+    out.push(multisig_call::CANCEL_AS_MULTI);
+    out.extend_from_slice(&threshold.to_le_bytes());
+    encode_account_id_vec(&mut out, other_signatories);
+    // Timepoint is required (not Option) for cancel.
+    encode_timepoint(&mut out, timepoint);
+    out.extend_from_slice(call_hash);
+    out
+}
+
+/// Sort a slice of 32-byte AccountIds lexicographically (raw bytes).
+///
+/// Mirrors `MultisigCalls.sortSignatories`.
+pub fn sort_signatories(signatories: &mut [Vec<u8>]) {
+    signatories.sort();
+}
+
+// ── SCALE helpers (private) ───────────────────────────────────────────────────
+
+fn encode_account_id_vec(out: &mut Vec<u8>, accounts: &[&[u8]]) {
+    out.extend_from_slice(&compact_usize(accounts.len()));
+    for acc in accounts {
+        assert_eq!(acc.len(), 32, "AccountId must be 32 bytes");
+        out.extend_from_slice(acc);
+    }
+}
+
+fn encode_option_timepoint(out: &mut Vec<u8>, tp: Option<(u32, u32)>) {
+    match tp {
+        None => out.push(0x00),
+        Some((height, index)) => {
+            out.push(0x01);
+            encode_timepoint(out, (height, index));
+        }
+    }
+}
+
+fn encode_timepoint(out: &mut Vec<u8>, (height, index): (u32, u32)) {
+    out.extend_from_slice(&height.to_le_bytes());
+    out.extend_from_slice(&index.to_le_bytes());
+}

--- a/crates/signer-core/src/extrinsic/call/scale.rs
+++ b/crates/signer-core/src/extrinsic/call/scale.rs
@@ -1,0 +1,52 @@
+//! Minimal hand-rolled SCALE compact encoding helpers.
+//!
+//! SCALE compact encoding (little-endian, mode bits in the lowest 2 bits):
+//!
+//! | Mode bits | Value range           | Encoding        |
+//! |-----------|----------------------|-----------------|
+//! | `00`      | 0–63                 | `(v << 2) as u8` (1 byte) |
+//! | `01`      | 64–16383             | `(v << 2 | 1) as u16 LE` (2 bytes) |
+//! | `10`      | 16384–1073741823     | `(v << 2 | 2) as u32 LE` (4 bytes) |
+//! | `11`      | 1073741824–bignum    | byte-length prefix + big-endian bytes |
+//!
+//! References:
+//! - https://docs.substrate.io/reference/scale-codec/
+//! - `parity-scale-codec` crate source (for reference only; we don't use it here
+//!   to avoid pulling a dependency into this narrow helper)
+
+use alloc::vec::Vec;
+
+/// SCALE Compact<u64> encoding.
+pub fn compact_u64(v: u64) -> Vec<u8> {
+    compact_u128(v as u128)
+}
+
+/// SCALE Compact<u128> encoding.
+pub fn compact_u128(v: u128) -> Vec<u8> {
+    if v < 64 {
+        vec![(v as u8) << 2]
+    } else if v < 16384 {
+        let encoded = ((v as u16) << 2) | 0b01;
+        encoded.to_le_bytes().to_vec()
+    } else if v < 1_073_741_824 {
+        let encoded = ((v as u32) << 2) | 0b10;
+        encoded.to_le_bytes().to_vec()
+    } else {
+        // Big-integer mode: find the minimum number of bytes needed.
+        let mut bytes = Vec::new();
+        let mut n = v;
+        while n > 0 {
+            bytes.push((n & 0xFF) as u8);
+            n >>= 8;
+        }
+        let len_byte = (((bytes.len() - 4) as u8) << 2) | 0b11;
+        let mut out = vec![len_byte];
+        out.extend_from_slice(&bytes);
+        out
+    }
+}
+
+/// SCALE Compact<usize> (same encoding, used for Vec length prefixes).
+pub fn compact_usize(v: usize) -> Vec<u8> {
+    compact_u128(v as u128)
+}

--- a/crates/signer-core/src/extrinsic/era.rs
+++ b/crates/signer-core/src/extrinsic/era.rs
@@ -1,0 +1,167 @@
+//! Substrate transaction era encoding.
+//!
+//! Mirrors `Era.kt` in `clad-mobile/shared/src/commonMain/kotlin/tech/wideas/clad/substrate/scale/`.
+//!
+//! # Era SCALE wire format
+//!
+//! - **Immortal**: single byte `0x00`
+//! - **Mortal(period, phase)**: 2 bytes (little-endian u16)
+//!   - `encoded_u16 = (log2(period) - 1).clamp(1, 15) | ((phase / quantize_factor) << 4)`
+//!   - `quantize_factor = max(1, period >> 12)`
+//!
+//! Decode is the inverse:
+//!   - `period = 2 << (encoded_u16 & 0x0F)`
+//!   - `phase  = (encoded_u16 >> 4) * quantize_factor`
+//!
+//! References:
+//! - `sp_runtime::generic::Era` in polkadot-sdk (source of truth)
+//! - Substrate extrinsic format docs
+
+use alloc::vec::Vec;
+
+/// Transaction validity period.
+///
+/// For government-focused users the default is `Immortal` (valid until
+/// included or nonce advances), matching `Era.Immortal` in `Era.kt`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Era {
+    /// Transaction is valid forever.
+    ///
+    /// SCALE: single byte `0x00`.
+    /// Block hash used in signing payload: genesis hash.
+    Immortal,
+    /// Transaction is only valid within a specific block range.
+    ///
+    /// SCALE: 2-byte little-endian u16 (see module doc).
+    /// Block hash used in signing payload: the recent block hash.
+    Mortal {
+        /// Number of blocks for which this transaction is valid.
+        /// Must be a power of 2 in the range 4–65536.
+        period: u64,
+        /// Phase within the period (derived from block number % period).
+        phase: u64,
+    },
+}
+
+impl Era {
+    /// SCALE-encode the era to bytes.
+    ///
+    /// Matches `sp_runtime::generic::Era::encode` in polkadot-sdk.
+    ///
+    /// Immortal → `[0x00]`
+    /// Mortal   → 2-byte little-endian u16
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            Era::Immortal => vec![0x00],
+            Era::Mortal { period, phase } => {
+                // `quantize_factor` reduces phase precision for very large periods.
+                // For period ≤ 4096 it is 1 (no quantisation).
+                let quantize_factor = (period >> 12).max(1);
+                // Low 4 bits: log2(period) - 1, clamped to 1..=15.
+                let period_bits = (period.trailing_zeros() - 1).clamp(1, 15) as u16;
+                // High 12 bits: quantised phase.
+                let phase_bits = ((phase / quantize_factor) << 4) as u16;
+                let encoded: u16 = period_bits | phase_bits;
+                encoded.to_le_bytes().to_vec()
+            }
+        }
+    }
+
+    /// Decode an era from a SCALE byte slice (1 or 2 bytes at the front).
+    ///
+    /// Matches `sp_runtime::generic::Era::decode` in polkadot-sdk.
+    ///
+    /// Returns `(era, bytes_consumed)`.
+    pub fn decode(data: &[u8]) -> Option<(Self, usize)> {
+        let b0 = *data.first()?;
+        if b0 == 0 {
+            Some((Era::Immortal, 1))
+        } else {
+            let b1 = *data.get(1)?;
+            let encoded = b0 as u64 | ((b1 as u64) << 8);
+            // `period = 2 << (encoded & 0x0F)` — inverse of `period.trailing_zeros() - 1`.
+            let period = 2u64 << (encoded & 0x0F);
+            let quantize_factor = (period >> 12).max(1);
+            let phase = (encoded >> 4) * quantize_factor;
+            Some((Era::Mortal { period, phase }, 2))
+        }
+    }
+
+    /// Return the block hash to include in the signing payload.
+    ///
+    /// - Immortal → genesis hash (matches `Era.Immortal.getBlockHashForSigning`)
+    /// - Mortal   → the recent block hash
+    pub fn block_hash_for_signing<'a>(
+        &self,
+        genesis_hash: &'a [u8],
+        block_hash: &'a [u8],
+    ) -> &'a [u8] {
+        match self {
+            Era::Immortal => genesis_hash,
+            Era::Mortal { .. } => block_hash,
+        }
+    }
+
+    /// Construct a mortal era from a current block number.
+    ///
+    /// `period_blocks` is rounded to the nearest power of 2 and clamped to 4–65536.
+    pub fn mortal_from_block(current_block: u64, period_blocks: u64) -> Self {
+        let period = next_power_of_two(period_blocks.clamp(4, 65536));
+        let quantize_factor = (period >> 12).max(1);
+        let phase = (current_block % period) / quantize_factor * quantize_factor;
+        Era::Mortal { period, phase }
+    }
+}
+
+/// Round `v` up to the next power of two, clamped to 65536.
+fn next_power_of_two(v: u64) -> u64 {
+    if v <= 1 {
+        return 1;
+    }
+    let p = (v - 1).leading_zeros();
+    let result = 1u64 << (64 - p);
+    result.min(65536)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn immortal_encodes_as_single_zero() {
+        assert_eq!(Era::Immortal.encode(), vec![0x00]);
+    }
+
+    #[test]
+    fn immortal_roundtrip() {
+        let (era, consumed) = Era::decode(&[0x00]).unwrap();
+        assert_eq!(era, Era::Immortal);
+        assert_eq!(consumed, 1);
+    }
+
+    #[test]
+    fn mortal_roundtrip() {
+        // period=64, phase=32 — cross-checked against polkadot-js and sp_runtime::generic::Era.
+        // Expected encoding: encoded_u16 = (6-1) | (32 << 4) = 5 | 512 = 517 = [0x05, 0x02]
+        let era = Era::Mortal { period: 64, phase: 32 };
+        let encoded = era.encode();
+        assert_eq!(encoded, vec![0x05, 0x02], "encoding must match Substrate wire format");
+        let (decoded, consumed) = Era::decode(&encoded).unwrap();
+        assert_eq!(consumed, 2);
+        if let Era::Mortal { period, phase } = decoded {
+            assert_eq!(period, 64);
+            assert_eq!(phase, 32);
+        } else {
+            panic!("expected Mortal");
+        }
+    }
+
+    #[test]
+    fn mortal_from_block_roundtrip() {
+        let era = Era::mortal_from_block(100, 64);
+        let encoded = era.encode();
+        assert_eq!(encoded.len(), 2);
+        let (decoded, _) = Era::decode(&encoded).unwrap();
+        assert_eq!(era, decoded);
+    }
+}

--- a/crates/signer-core/src/extrinsic/metadata.rs
+++ b/crates/signer-core/src/extrinsic/metadata.rs
@@ -1,0 +1,136 @@
+//! Metadata-aware call encoding.
+//!
+//! # Current status — hand-rolled SCALE only (subxt-core deferred)
+//!
+//! The spec (Phase 2 execution plan) originally proposed integrating
+//! `subxt-core 0.38` to dynamically verify call indices against live
+//! `Metadata V15`.  That integration is **deferred to Phase 2b / Phase 3**
+//! for the following reasons:
+//!
+//! 1. `subxt-core 0.38` depends on `subxt-metadata 0.38`, which in turn
+//!    depends on `scale-decode`, `scale-encode`, and `frame-metadata` with
+//!    transitive `std`-only paths that make reliable `no_std + alloc`
+//!    compilation non-trivial without forking.
+//! 2. `pallet-clad-token` has stable, manually audited call indices (0–6 for
+//!    pallet 8) that are unlikely to change in isolation; hard-coding them
+//!    with a test-time cross-check is sufficient for Phase 2.
+//! 3. The metadata corpus (`tests/corpora/metadata/`) requires a live
+//!    `clad-node --dev` instance to regenerate, which is not available in
+//!    this environment.
+//!
+//! When Phase 2b / Phase 3 adds subxt-core, this module should:
+//! - Accept a serialized `Metadata V15` blob.
+//! - Resolve pallet name → pallet index and call name → call index dynamically.
+//! - Validate that the hardcoded constants in `call.rs` match the live metadata.
+//!
+//! Track as: **[Phase 2 / PR #TBD] subxt-core integration — metadata-aware call encoding**
+
+use crate::crypto::CryptoError;
+use alloc::vec::Vec;
+
+use super::call::{
+    add_to_whitelist, freeze, mint, remove_from_whitelist, set_admin, transfer, unfreeze, CallData,
+    CLAD_TOKEN_PALLET,
+};
+
+/// Known pallet names and their fixed indices in the Clad runtime.
+///
+/// Source: `runtime/src/lib.rs` `construct_runtime!` and `MultisigPalletConfig.PALLET_INDEX`.
+///
+/// These are the indices that would be resolved dynamically by subxt-core once
+/// that integration lands.  They are audited constants for now.
+pub const KNOWN_PALLETS: &[(&str, u8)] = &[("CladToken", CLAD_TOKEN_PALLET), ("Multisig", 7)];
+
+/// Build call data given a pallet name, call name, and raw argument bytes.
+///
+/// This is a thin dispatch layer over the typed builders in `call.rs`.
+/// Only `CladToken` pallet calls are supported; all others return
+/// [`CryptoError::UnknownPallet`] or [`CryptoError::UnknownCall`].
+///
+/// The `args` slice must contain SCALE-pre-encoded arguments in the order
+/// expected by the call. Specifically:
+///
+/// | call            | args[0]              | args[1] (optional) |
+/// |-----------------|----------------------|--------------------|
+/// | `mint`          | AccountId (32 bytes) | Compact<u128> amount |
+/// | `transfer`      | AccountId (32 bytes) | Compact<u128> amount |
+/// | `freeze`        | AccountId (32 bytes) | — |
+/// | `unfreeze`      | AccountId (32 bytes) | — |
+/// | `add_to_whitelist`    | AccountId (32 bytes) | — |
+/// | `remove_from_whitelist` | AccountId (32 bytes) | — |
+/// | `set_admin`     | AccountId (32 bytes) | — |
+///
+/// For `mint` and `transfer`, `args[1]` is a raw little-endian u128 (16 bytes).
+pub fn build_call_data(
+    pallet_name: &str,
+    call_name: &str,
+    args: &[Vec<u8>],
+) -> Result<CallData, CryptoError> {
+    match pallet_name {
+        "CladToken" => build_clad_token_call(call_name, args),
+        _ => Err(CryptoError::UnknownPallet),
+    }
+}
+
+fn build_clad_token_call(call_name: &str, args: &[Vec<u8>]) -> Result<CallData, CryptoError> {
+    match call_name {
+        "mint" | "transfer" => {
+            let account = args.first().ok_or(CryptoError::UnknownCall)?;
+            let amount_bytes = args.get(1).ok_or(CryptoError::UnknownCall)?;
+            if amount_bytes.len() != 16 {
+                return Err(CryptoError::UnknownCall);
+            }
+            let amount = u128::from_le_bytes(
+                amount_bytes.as_slice().try_into().map_err(|_| CryptoError::UnknownCall)?,
+            );
+            if call_name == "mint" {
+                Ok(mint(account, amount))
+            } else {
+                Ok(transfer(account, amount))
+            }
+        }
+        "freeze" => {
+            let account = args.first().ok_or(CryptoError::UnknownCall)?;
+            Ok(freeze(account))
+        }
+        "unfreeze" => {
+            let account = args.first().ok_or(CryptoError::UnknownCall)?;
+            Ok(unfreeze(account))
+        }
+        "add_to_whitelist" => {
+            let account = args.first().ok_or(CryptoError::UnknownCall)?;
+            Ok(add_to_whitelist(account))
+        }
+        "remove_from_whitelist" => {
+            let account = args.first().ok_or(CryptoError::UnknownCall)?;
+            Ok(remove_from_whitelist(account))
+        }
+        "set_admin" => {
+            let account = args.first().ok_or(CryptoError::UnknownCall)?;
+            Ok(set_admin(account))
+        }
+        _ => Err(CryptoError::UnknownCall),
+    }
+}
+
+/// Validate that the hardcoded pallet/call indices match the expected values.
+///
+/// This is a compile-time / unit-test cross-check.  Once subxt-core lands, this
+/// function should additionally cross-check against the live metadata blob.
+pub fn validate_known_call_indices(pallet_name: &str, call_name: &str) -> Option<(u8, u8)> {
+    let pallet_idx =
+        KNOWN_PALLETS.iter().find(|(name, _)| *name == pallet_name).map(|(_, idx)| *idx)?;
+
+    let call_idx = match (pallet_name, call_name) {
+        ("CladToken", "mint") => 0,
+        ("CladToken", "transfer") => 1,
+        ("CladToken", "freeze") => 2,
+        ("CladToken", "unfreeze") => 3,
+        ("CladToken", "add_to_whitelist") => 4,
+        ("CladToken", "remove_from_whitelist") => 5,
+        ("CladToken", "set_admin") => 6,
+        _ => return None,
+    };
+
+    Some((pallet_idx, call_idx))
+}

--- a/crates/signer-core/src/extrinsic/mod.rs
+++ b/crates/signer-core/src/extrinsic/mod.rs
@@ -1,0 +1,29 @@
+//! Substrate extrinsic construction.
+//!
+//! Mirrors the Kotlin oracle files in
+//! `clad-mobile/shared/src/commonMain/kotlin/tech/wideas/clad/substrate/extrinsic/`
+//! and produces bit-identical SCALE-encoded call data and signed extrinsics.
+//!
+//! All modules are `no_std + alloc` compatible.
+//!
+//! # Module layout
+//!
+//! - [`era`]              — `Era::Immortal` / `Era::Mortal` SCALE encoding
+//! - [`call`]             — `CladTokenCalls` + `MultisigCalls` call builders
+//! - [`signed_extensions`] — Extra (era + nonce + tip) and Additional fields
+//! - [`payload`]          — `build_signing_payload` + ≥ 256-byte Blake2b rule
+//! - [`signed`]           — `build_signed_extrinsic`, `complete_with_signature`
+//! - [`metadata`]         — hand-rolled call encoding; subxt-core deferred
+
+pub mod call;
+pub mod era;
+pub mod metadata;
+pub mod payload;
+pub mod signed;
+pub mod signed_extensions;
+
+// Re-export the primary user-facing types.
+pub use call::CallData;
+pub use era::Era;
+pub use signed::SignedExtrinsic;
+pub use signed_extensions::{ChainInfo, SignedExtra};

--- a/crates/signer-core/src/extrinsic/payload.rs
+++ b/crates/signer-core/src/extrinsic/payload.rs
@@ -1,0 +1,44 @@
+//! Signing payload construction.
+//!
+//! Mirrors `ExtrinsicBuilder.buildSigningPayload` in
+//! `clad-mobile/shared/src/commonMain/kotlin/tech/wideas/clad/substrate/extrinsic/ExtrinsicBuilder.kt`.
+//!
+//! # Signing payload wire format
+//!
+//! ```text
+//! call_data || extra || additional
+//! ```
+//!
+//! If `len(payload) >= 256`, Blake2b-256-hash it before signing.
+//! This matches `MAX_PAYLOAD_SIZE_FOR_RAW_SIGNING = 256` in `ExtrinsicBuilder.kt`.
+//!
+//! References:
+//! - Substrate `sp_runtime::generic::UncheckedExtrinsic::signature_payload`
+
+use alloc::vec::Vec;
+
+use crate::crypto::blake2::blake2b_256;
+
+use super::signed_extensions::{ChainInfo, SignedExtra};
+
+/// Maximum payload size (bytes) before Blake2b-256 hashing is required.
+///
+/// Source: `ExtrinsicBuilder.MAX_PAYLOAD_SIZE_FOR_RAW_SIGNING = 256`.
+pub const MAX_PAYLOAD_SIZE_FOR_RAW_SIGNING: usize = 256;
+
+/// Build the signing payload for a call.
+///
+/// Concatenates `call_data || extra || additional` then, if the result is ≥ 256
+/// bytes, replaces it with its Blake2b-256 hash (32 bytes).
+pub fn build_signing_payload(call_data: &[u8], extra: &SignedExtra, chain: &ChainInfo) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(call_data.len() + 64 + 72);
+    payload.extend_from_slice(call_data);
+    payload.extend_from_slice(&extra.encode_extra());
+    payload.extend_from_slice(&extra.encode_additional(chain));
+
+    if payload.len() >= MAX_PAYLOAD_SIZE_FOR_RAW_SIGNING {
+        blake2b_256(&payload)
+    } else {
+        payload
+    }
+}

--- a/crates/signer-core/src/extrinsic/signed.rs
+++ b/crates/signer-core/src/extrinsic/signed.rs
@@ -1,0 +1,118 @@
+//! Signed extrinsic construction.
+//!
+//! Mirrors `ExtrinsicBuilder.buildExtrinsicData` and `buildSignedExtrinsic` in
+//! `clad-mobile/shared/src/commonMain/kotlin/tech/wideas/clad/substrate/extrinsic/ExtrinsicBuilder.kt`.
+//!
+//! # Signed extrinsic wire format (Substrate v4)
+//!
+//! ```text
+//! Compact<length> || ExtrinsicData
+//!
+//! ExtrinsicData =
+//!     version_byte(0x84)        -- signed(bit7) | version(4)
+//!     || address                -- MultiAddress::Id: 0x00 || AccountId(32)
+//!     || signature              -- MultiSignature::Sr25519: 0x01 || sig(64)
+//!     || extra                  -- Era || Compact<Nonce> || Compact<Tip>
+//!     || call_data              -- pallet_index || call_index || params
+//! ```
+//!
+//! The extrinsic hash is Blake2b-256 of the complete length-prefixed bytes.
+
+use alloc::vec::Vec;
+
+use crate::crypto::blake2::blake2b_256;
+
+use super::call::scale::compact_usize;
+use super::signed_extensions::SignedExtra;
+
+/// Version byte: signed(bit7=1) | format version 4.
+const SIGNED_EXTRINSIC_VERSION: u8 = 0x84;
+
+/// `MultiAddress::Id` enum variant — raw AccountId (32 bytes).
+const MULTI_ADDRESS_ID: u8 = 0x00;
+
+/// `MultiSignature::Sr25519` enum variant — 64-byte signature.
+const MULTI_SIGNATURE_SR25519: u8 = 0x01;
+
+/// A complete signed extrinsic ready for submission.
+///
+/// Maps to `SignedExtrinsic` in `ExtrinsicBuilder.kt`.
+#[derive(Debug, Clone)]
+pub struct SignedExtrinsic {
+    /// Complete SCALE-encoded extrinsic (with compact length prefix).
+    pub encoded: Vec<u8>,
+    /// Blake2b-256 hash of `encoded` (for transaction tracking).
+    pub hash: Vec<u8>,
+}
+
+/// Build a signed extrinsic from pre-computed parts.
+///
+/// Arguments:
+/// - `call_data`: SCALE-encoded call (pallet + call index + params)
+/// - `signer_public_key`: 32-byte SR25519 public key
+/// - `signature`: 64-byte SR25519 signature over the signing payload
+/// - `extra`: signed extension fields (era, nonce, tip)
+pub fn build_signed_extrinsic(
+    call_data: &[u8],
+    signer_public_key: &[u8],
+    signature: &[u8],
+    extra: &SignedExtra,
+) -> SignedExtrinsic {
+    let body = build_extrinsic_body(call_data, signer_public_key, signature, extra);
+    wrap_with_length(body)
+}
+
+/// Complete an unsigned extrinsic payload with an externally computed signature.
+///
+/// Identical to [`build_signed_extrinsic`] — separated to mirror the Kotlin API
+/// (`completeWithSignature` vs `buildSignedExtrinsic`).
+pub fn complete_with_signature(
+    call_data: &[u8],
+    signer_public_key: &[u8],
+    signature: &[u8],
+    extra: &SignedExtra,
+) -> SignedExtrinsic {
+    build_signed_extrinsic(call_data, signer_public_key, signature, extra)
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+/// Encode the inner extrinsic body (without the compact-length prefix).
+fn build_extrinsic_body(
+    call_data: &[u8],
+    signer_public_key: &[u8],
+    signature: &[u8],
+    extra: &SignedExtra,
+) -> Vec<u8> {
+    assert_eq!(signer_public_key.len(), 32, "public key must be 32 bytes");
+    assert_eq!(signature.len(), 64, "signature must be 64 bytes");
+
+    let mut out = Vec::with_capacity(1 + 33 + 65 + 64 + call_data.len());
+
+    // version byte
+    out.push(SIGNED_EXTRINSIC_VERSION);
+
+    // address: MultiAddress::Id (0x00 + raw AccountId)
+    out.push(MULTI_ADDRESS_ID);
+    out.extend_from_slice(signer_public_key);
+
+    // signature: MultiSignature::Sr25519 (0x01 + 64 bytes)
+    out.push(MULTI_SIGNATURE_SR25519);
+    out.extend_from_slice(signature);
+
+    // extra (era, nonce, tip)
+    out.extend_from_slice(&extra.encode_extra());
+
+    // call data
+    out.extend_from_slice(call_data);
+
+    out
+}
+
+/// Prepend SCALE compact length and compute the extrinsic hash.
+fn wrap_with_length(body: Vec<u8>) -> SignedExtrinsic {
+    let mut encoded = compact_usize(body.len());
+    encoded.extend_from_slice(&body);
+    let hash = blake2b_256(&encoded);
+    SignedExtrinsic { encoded, hash }
+}

--- a/crates/signer-core/src/extrinsic/signed_extensions.rs
+++ b/crates/signer-core/src/extrinsic/signed_extensions.rs
@@ -1,0 +1,100 @@
+//! Substrate signed extensions encoding.
+//!
+//! Mirrors `SignedExtensions.kt` from
+//! `clad-mobile/shared/src/commonMain/kotlin/tech/wideas/clad/substrate/extrinsic/`.
+//!
+//! # Extra (serialized into the extrinsic after the signature)
+//!
+//! ```text
+//! Era || Compact<Nonce> || Compact<Tip>
+//! ```
+//!
+//! # Additional (signed but NOT serialized into the extrinsic)
+//!
+//! ```text
+//! spec_version(u32 LE) || tx_version(u32 LE) || genesis_hash([u8;32]) || block_hash([u8;32])
+//! ```
+//!
+//! The `block_hash` field is the genesis hash for immortal transactions and
+//! the recent block hash for mortal transactions.
+
+use alloc::vec::Vec;
+
+use super::call::scale::{compact_u128, compact_u64};
+use super::era::Era;
+
+/// Chain information required for transaction construction and signing.
+///
+/// Maps to the Kotlin `ChainInfo` data class in `SignedExtensions.kt`.
+#[derive(Debug, Clone)]
+pub struct ChainInfo {
+    /// Genesis hash of the chain (32 bytes).
+    pub genesis_hash: Vec<u8>,
+    /// Recent block hash used for mortal era signing (32 bytes).
+    /// For immortal transactions this should equal `genesis_hash`.
+    pub block_hash: Vec<u8>,
+    /// Runtime spec version (from `state_getRuntimeVersion`).
+    pub spec_version: u32,
+    /// Transaction format version (from `state_getRuntimeVersion`).
+    pub tx_version: u32,
+}
+
+/// Signed extension fields attached to an extrinsic.
+///
+/// Maps to the Kotlin `SignedExtensions` data class.
+///
+/// Field names are aligned with the UDL dictionary so UniFFI can map them
+/// without a conversion layer.
+#[derive(Debug, Clone)]
+pub struct SignedExtra {
+    /// Era period (number of blocks for which the transaction is valid).
+    /// Set to 0 for an immortal transaction.
+    /// For mortal transactions: a power of 2 in the range 4–65536.
+    pub era_period: u64,
+    /// Era phase (`current_block % era_period`).  Set to 0 for immortal.
+    pub era_phase: u64,
+    /// Account nonce (prevents replay).
+    pub nonce: u64,
+    /// Priority tip (usually 0).
+    ///
+    /// `u64` at the FFI boundary (UniFFI 0.28 does not support `u128`).
+    /// SCALE-encoded as `Compact<u128>` by zero-extending at encoding time.
+    pub tip: u64,
+}
+
+impl SignedExtra {
+    /// Derive a [`Era`] value from the `era_period` / `era_phase` fields.
+    fn era(&self) -> Era {
+        if self.era_period == 0 {
+            Era::Immortal
+        } else {
+            Era::Mortal { period: self.era_period, phase: self.era_phase }
+        }
+    }
+
+    /// Encode the **extra** portion: `Era || Compact<Nonce> || Compact<Tip>`.
+    ///
+    /// This is appended to the extrinsic after the signature.
+    pub fn encode_extra(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&self.era().encode());
+        out.extend_from_slice(&compact_u64(self.nonce));
+        out.extend_from_slice(&compact_u128(self.tip as u128));
+        out
+    }
+
+    /// Encode the **additional** portion: `spec_version || tx_version || genesis_hash || block_hash`.
+    ///
+    /// This is signed but NOT included in the extrinsic wire format.
+    /// `block_hash` is chosen based on the era (genesis for immortal, recent block for mortal).
+    pub fn encode_additional(&self, chain: &ChainInfo) -> Vec<u8> {
+        let era = self.era();
+        let block_hash = era.block_hash_for_signing(&chain.genesis_hash, &chain.block_hash);
+        let mut out = Vec::new();
+        out.extend_from_slice(&chain.spec_version.to_le_bytes());
+        out.extend_from_slice(&chain.tx_version.to_le_bytes());
+        out.extend_from_slice(&chain.genesis_hash);
+        out.extend_from_slice(block_hash);
+        out
+    }
+}

--- a/crates/signer-core/src/lib.rs
+++ b/crates/signer-core/src/lib.rs
@@ -1,3 +1,23 @@
+//! # signer-core
+//!
+//! Shared protocol and crypto primitives for the Clad Sovereign signer.
+//!
+//! **Phase 2 status:** the `crypto` and `extrinsic` modules are now available
+//! and provide SR25519/ED25519 signing, Blake2b hashing, SS58 encoding, and
+//! SCALE-encoded extrinsic construction.  The `uos` module (Phase 1) is
+//! unchanged.
+//!
+//! See ADR-007 (`docs/adr/007-rust-signer-core-via-uniffi.md`) for the
+//! architectural motivation.
+//!
+//! # no_std note
+//!
+//! The `crypto` and `extrinsic` modules are written using `alloc::` types
+//! exclusively and are no_std-compatible in isolation (ADR-007 Phase-2 NFC
+//! requirement).  The crate itself links std because UniFFI 0.28 scaffolding
+//! generates `std`-using code; a std-free firmware build would exclude the
+//! UniFFI surface and depend on `signer-core` as a library crate directly.
+
 // `empty_line_after_doc_comments` is suppressed at crate level because the
 // UniFFI 0.28 scaffolding generator (invoked below via `include_scaffolding!`)
 // emits `///`-style doc comments followed by a blank line on top-level
@@ -6,21 +26,18 @@
 // (deferred to Phase 3 prep per the restructure roadmap).
 #![allow(clippy::empty_line_after_doc_comments)]
 
-//! # signer-core
-//!
-//! Shared protocol and crypto primitives for the Clad Sovereign signer.
-//!
-//! **Phase 1 status:** the `uos` module is now available and provides a
-//! byte-for-byte Rust port of the UOS (Universal Offline Signatures) protocol
-//! from `clad-mobile/shared/`.  Sr25519 signing primitives and SCALE extrinsic
-//! construction land in Phase 2.  Neither mobile app consumes this Rust path
-//! until Phase 3 (feature-flag wiring).
-//!
-//! See ADR-007 (`docs/adr/007-rust-signer-core-via-uniffi.md`) for the
-//! architectural motivation.
+// `alloc` is explicitly declared so the `crypto` and `extrinsic` modules can
+// use `alloc::` paths, ensuring they stay compatible with no_std targets
+// (e.g., future NFC firmware builds that won't include UniFFI).
+extern crate alloc;
 
+pub mod crypto;
+pub mod extrinsic;
 pub mod uos;
 
+pub use crypto::CryptoError;
+pub use crypto::{blake2, ed25519, sr25519, ss58};
+pub use extrinsic::{CallData, ChainInfo, Era, SignedExtra, SignedExtrinsic};
 pub use uos::account_introduction::AccountIntroduction;
 pub use uos::error::UosError;
 pub use uos::multipart::{FrameDecodeProgress, MultiPartQrDecoder, MultiPartQrEncoder};
@@ -74,4 +91,83 @@ pub fn account_intro_to_uri(account: AccountIntroduction) -> String {
 /// Parses an [`AccountIntroduction`] from a `substrate:…` URI.
 pub fn account_intro_from_uri(uri: String) -> Result<AccountIntroduction, UosError> {
     AccountIntroduction::from_uri(&uri)
+}
+
+// ── Phase 2: Crypto free functions ───────────────────────────────────────────
+
+/// Encode a 32-byte public key as an SS58 address with the given prefix.
+pub fn ss58_encode(public_key: Vec<u8>, prefix: u16) -> Result<String, CryptoError> {
+    ss58::encode(&public_key, prefix)
+}
+
+/// Decode an SS58 address, returning the 32-byte public key.
+pub fn ss58_decode(address: String) -> Result<Vec<u8>, CryptoError> {
+    let (pk, _prefix) = ss58::decode(&address)?;
+    Ok(pk)
+}
+
+/// Sign a payload with SR25519 using the provided 32-byte seed.
+pub fn sr25519_sign(signing_payload: Vec<u8>, secret_key: Vec<u8>) -> Result<Vec<u8>, CryptoError> {
+    sr25519::sign(&signing_payload, &secret_key)
+}
+
+/// Verify an SR25519 signature.
+pub fn sr25519_verify(message: Vec<u8>, signature: Vec<u8>, public_key: Vec<u8>) -> bool {
+    sr25519::verify(&message, &signature, &public_key)
+}
+
+/// Sign a payload with ED25519 using the provided 32-byte seed.
+pub fn ed25519_sign(signing_payload: Vec<u8>, secret_key: Vec<u8>) -> Result<Vec<u8>, CryptoError> {
+    ed25519::sign(&signing_payload, &secret_key)
+}
+
+/// Verify an ED25519 signature.
+pub fn ed25519_verify(message: Vec<u8>, signature: Vec<u8>, public_key: Vec<u8>) -> bool {
+    ed25519::verify(&message, &signature, &public_key)
+}
+
+/// Compute a 32-byte Blake2b-256 hash of `data`.
+pub fn blake2b_256(data: Vec<u8>) -> Vec<u8> {
+    blake2::blake2b_256(&data)
+}
+
+// ── Phase 2: Extrinsic free functions ────────────────────────────────────────
+
+/// Build SCALE-encoded call data by pallet + call name with pre-encoded args.
+pub fn build_call_data(
+    pallet_name: String,
+    call_name: String,
+    args: Vec<Vec<u8>>,
+) -> Result<Vec<u8>, CryptoError> {
+    extrinsic::metadata::build_call_data(&pallet_name, &call_name, &args)
+}
+
+/// Build the signing payload for a call (applies Blake2b-256 if ≥ 256 bytes).
+pub fn build_signing_payload(call_data: Vec<u8>, extra: SignedExtra, chain: ChainInfo) -> Vec<u8> {
+    extrinsic::payload::build_signing_payload(&call_data, &extra, &chain)
+}
+
+/// Build a signed extrinsic from call data, public key, and signature.
+pub fn build_signed_extrinsic(
+    call_data: Vec<u8>,
+    signer_public_key: Vec<u8>,
+    signature: Vec<u8>,
+    extra: SignedExtra,
+) -> SignedExtrinsic {
+    extrinsic::signed::build_signed_extrinsic(&call_data, &signer_public_key, &signature, &extra)
+}
+
+/// Complete an unsigned extrinsic payload with an externally produced signature.
+pub fn complete_with_signature(
+    call_data: Vec<u8>,
+    signer_public_key: Vec<u8>,
+    signature: Vec<u8>,
+    extra: SignedExtra,
+) -> SignedExtrinsic {
+    extrinsic::signed::complete_with_signature(&call_data, &signer_public_key, &signature, &extra)
+}
+
+/// Compute the Blake2b-256 hash of call data (used as multisig call_hash).
+pub fn compute_call_hash(call_data: Vec<u8>) -> Vec<u8> {
+    blake2::blake2b_256(&call_data)
 }

--- a/crates/signer-core/src/signer_core.udl
+++ b/crates/signer-core/src/signer_core.udl
@@ -3,19 +3,36 @@
 // Phase 0 established the `ping()` liveness function and the cross-compile
 // pipeline.  Phase 1 adds the complete UOS (Universal Offline Signatures)
 // surface: payload codec, signature codec, multi-part QR codec, and the
-// account-introduction URI codec.
+// account-introduction URI codec.  Phase 2 adds the crypto and extrinsic
+// surface (sr25519, ed25519, blake2, ss58, extrinsic construction).
 //
 // ADR-007 governs the FFI boundary rules; in particular:
-//   - No `Option<Result<…>>` shapes — all error paths use `[Throws=UosError]`.
-//   - `UosError` is a sealed flat enum; contextual detail lives in the error's
+//   - No `Option<Result<…>>` shapes — all error paths use `[Throws=...]`.
+//   - Error enums are sealed and flat; contextual detail lives in the error's
 //     `message` string (accessible on Kotlin via `.message`, Swift via
 //     `localizedDescription`).
 //   - `bytes` ↔ `Vec<u8>` / `ByteArray` / `Data`; `boolean` ↔ `bool`.
 //   - Dictionary fields use snake_case matching the Rust struct field names.
 //
+// Phase 2 surface note: the crypto and extrinsic functions below are marked
+// "Phase 2 preview, may evolve in Phase 3" — the FFI surface is conservative
+// (pure functions only, no interface objects) to minimise binding-format drift.
+//
 // UniFFI version: 0.28.3 (upgrade deferred to Phase 3 prep).
 
-// ── Error type ───────────────────────────────────────────────────────────────
+// ── Error types ───────────────────────────────────────────────────────────────
+
+[Error]
+enum CryptoError {
+    "InvalidSecretKey",
+    "InvalidPublicKey",
+    "InvalidSignature",
+    "InvalidAddress",
+    "InvalidPrefix",
+    "InvalidMetadata",
+    "UnknownPallet",
+    "UnknownCall",
+};
 
 [Error]
 enum UosError {
@@ -30,7 +47,38 @@ enum UosError {
     "InvalidUri",
 };
 
-// ── Value types (dictionaries) ───────────────────────────────────────────────
+// ── Phase 2 value types ───────────────────────────────────────────────────────
+
+/// Chain information required for extrinsic signing.
+dictionary ChainInfo {
+    bytes genesis_hash;
+    bytes block_hash;
+    u32 spec_version;
+    u32 tx_version;
+};
+
+/// Signed extension fields (era, nonce, tip).
+///
+/// era_period == 0 means Immortal.  For mortal transactions set era_period to a
+/// power of 2 in the range 4–65536 and era_phase to current_block % era_period.
+///
+/// tip is u64 (UniFFI 0.28 does not support u128 at the FFI boundary).
+/// Practical tip values always fit in u64; the SCALE encoder zero-extends to
+/// Compact<u128> when building the signed extension bytes.
+dictionary SignedExtra {
+    u64 era_period;
+    u64 era_phase;
+    u64 nonce;
+    u64 tip;
+};
+
+/// A complete signed extrinsic ready for RPC submission.
+dictionary SignedExtrinsic {
+    bytes encoded;
+    bytes hash;
+};
+
+// ── Phase 1 value types (dictionaries) ───────────────────────────────────────
 
 /// Decoded unsigned transaction payload.
 dictionary UosPayload {
@@ -112,4 +160,45 @@ namespace signer_core {
 
     [Throws=UosError]
     AccountIntroduction account_intro_from_uri(string uri);
+
+    // ── Phase 2: crypto ───────────────────────────────────────────────────
+    [Throws=CryptoError]
+    string ss58_encode(bytes public_key, u16 prefix);
+
+    [Throws=CryptoError]
+    bytes ss58_decode(string address);
+
+    [Throws=CryptoError]
+    bytes sr25519_sign(bytes signing_payload, bytes secret_key);
+
+    boolean sr25519_verify(bytes message, bytes signature, bytes public_key);
+
+    [Throws=CryptoError]
+    bytes ed25519_sign(bytes signing_payload, bytes secret_key);
+
+    boolean ed25519_verify(bytes message, bytes signature, bytes public_key);
+
+    bytes blake2b_256(bytes data);
+
+    // ── Phase 2: extrinsic ────────────────────────────────────────────────
+    [Throws=CryptoError]
+    bytes build_call_data(string pallet_name, string call_name, sequence<bytes> args);
+
+    bytes build_signing_payload(bytes call_data, SignedExtra extra, ChainInfo chain);
+
+    SignedExtrinsic build_signed_extrinsic(
+        bytes call_data,
+        bytes signer_public_key,
+        bytes signature,
+        SignedExtra extra
+    );
+
+    SignedExtrinsic complete_with_signature(
+        bytes call_data,
+        bytes signer_public_key,
+        bytes signature,
+        SignedExtra extra
+    );
+
+    bytes compute_call_hash(bytes call_data);
 };

--- a/crates/signer-core/tests/corpora/README.md
+++ b/crates/signer-core/tests/corpora/README.md
@@ -1,9 +1,17 @@
-# UOS Protocol Test Corpora
+# signer-core Test Corpora
 
-This directory contains **golden test vectors** for the Rust port of the UOS
-(Universal Offline Signatures) protocol.  Each JSON file encodes a fixed input
-and the expected binary output.  The corpus tests in `tests/uos_*_corpus.rs`
-load these files and assert that the Rust implementation produces identical bytes.
+This directory contains **golden test vectors** for the Rust port of two
+protocol layers:
+
+- **Phase 1 (UOS):** Universal Offline Signatures encode/decode.  Vectors
+  generated from the Kotlin oracle.
+- **Phase 2 (crypto + extrinsic):** SR25519/ED25519 signing, Blake2b hashing,
+  SS58 encoding, and SCALE-encoded Substrate call data.  Vectors sourced from
+  public Substrate test vectors (Alice key, SS58 prefix 42) or computed from
+  audited constants; Kotlin oracle extraction deferred to Phase 2b.
+
+Each JSON file encodes a fixed input and expected output.  The corpus tests load
+these files at runtime and assert the Rust implementation produces identical output.
 
 ---
 
@@ -44,7 +52,7 @@ compares the Rust output against itself.
 
 ```
 corpora/
-├── payload/              # UosPayload encode/decode tests
+├── payload/              # UosPayload encode/decode tests  (Phase 1 / Kotlin oracle)
 │   ├── sign_tx_empty.json
 │   ├── sign_tx_1byte.json
 │   ├── sign_tx_1024bytes.json
@@ -52,22 +60,28 @@ corpora/
 │   ├── sign_immortal_*.json
 │   ├── sign_hash_*.json
 │   └── sign_message_*.json
-├── signature/            # UosSignature encode/decode tests
+├── signature/            # UosSignature encode/decode tests  (Phase 1 / Kotlin oracle)
 │   ├── sr25519_zeros.json
 │   ├── sr25519_nonzero.json
 │   ├── ed25519_*.json
 │   └── ecdsa_*.json
-├── multipart/            # MultiPartQr{Encoder,Decoder} tests
+├── multipart/            # MultiPartQr{Encoder,Decoder} tests  (Phase 1 / Kotlin oracle)
 │   ├── single_frame.json
 │   ├── three_frame_balanced.json
 │   ├── three_frame_uneven_tail.json
 │   └── large_5kb.json
-└── account_introduction/ # AccountIntroduction URI tests
-    ├── minimal.json
-    ├── with_genesis.json
-    ├── with_name_ascii.json
-    ├── with_name_unicode.json
-    └── with_name_reserved_chars.json
+├── account_introduction/ # AccountIntroduction URI tests  (Phase 1 / Kotlin oracle)
+│   ├── minimal.json
+│   ├── with_genesis.json
+│   ├── with_name_ascii.json
+│   ├── with_name_unicode.json
+│   └── with_name_reserved_chars.json
+├── crypto/               # Crypto KAT vectors  (Phase 2; Kotlin oracle pending Phase 2b)
+│   ├── ss58_encode.json  # Alice pubkey + prefix 42 → SS58 address
+│   ├── ss58_decode.json  # Alice SS58 address → pubkey + prefix
+│   └── blake2b_256.json  # Blake2b-256 known-answer vectors
+└── extrinsic/            # SCALE call data vectors  (Phase 2; Kotlin oracle pending Phase 2b)
+    └── call_data.json    # CladToken calls (mint, transfer, freeze, …) for Alice AccountId
 ```
 
 ---
@@ -158,6 +172,56 @@ The `name` field is URL-encoded per `application/x-www-form-urlencoded` (Java
 - Everything else → `%XX` (two uppercase hex digits)
 
 This matches the Kotlin reference implementation's encoding exactly.
+
+### Phase 2 — crypto/ss58_encode.json
+
+```json
+{
+  "description": "...",
+  "input": { "public_key_hex": "<64 hex chars>", "prefix": 42 },
+  "expected_address": "<SS58 string>"
+}
+```
+
+### Phase 2 — crypto/ss58_decode.json
+
+```json
+{
+  "description": "...",
+  "input": { "address": "<SS58 string>" },
+  "expected_public_key_hex": "<64 hex chars>",
+  "expected_prefix": 42
+}
+```
+
+### Phase 2 — crypto/blake2b_256.json
+
+```json
+{
+  "description": "...",
+  "vectors": [
+    { "description": "...", "input_hex": "<hex>", "expected_hash_hex": "<64 hex chars>" }
+  ]
+}
+```
+
+### Phase 2 — extrinsic/call_data.json
+
+```json
+{
+  "description": "...",
+  "alice_account_hex": "<64 hex chars>",
+  "vectors": [
+    {
+      "call": "mint",
+      "args": { "account_hex": "<64 hex>", "amount": 1 },
+      "expected_bytes_hex": "<hex of [pallet_u8][call_u8][0x00][32-byte AccountId][compact amount]>"
+    }
+  ]
+}
+```
+
+Wire format: `[pallet_index: u8][call_index: u8][0x00 MultiAddress::Id][32-byte AccountId][optional SCALE Compact<u128> amount]`
 
 ---
 

--- a/crates/signer-core/tests/corpora/crypto/blake2b_256.json
+++ b/crates/signer-core/tests/corpora/crypto/blake2b_256.json
@@ -1,0 +1,10 @@
+{
+  "description": "Blake2b-256 known-answer vectors. The empty-string hash is a widely-published reference value. Additional Kotlin-oracle vectors deferred to Phase 2b.",
+  "vectors": [
+    {
+      "description": "BLAKE2b-256 of empty input — reference value from blake2.net and RFC 7693 appendix.",
+      "input_hex": "",
+      "expected_hash_hex": "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+    }
+  ]
+}

--- a/crates/signer-core/tests/corpora/crypto/ss58_decode.json
+++ b/crates/signer-core/tests/corpora/crypto/ss58_decode.json
@@ -1,0 +1,8 @@
+{
+  "description": "SS58 decode: standard Substrate Alice address → 32-byte public key and prefix 42. Inverse of ss58_encode.json.",
+  "input": {
+    "address": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+  },
+  "expected_public_key_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+  "expected_prefix": 42
+}

--- a/crates/signer-core/tests/corpora/crypto/ss58_encode.json
+++ b/crates/signer-core/tests/corpora/crypto/ss58_encode.json
@@ -1,0 +1,8 @@
+{
+  "description": "SS58 encode: Alice sr25519 public key with prefix 42 → standard Substrate address. Cross-checked against polkadot-js (https://polkadot.js.org/apps/#/accounts) and the Substrate `sp_core::crypto::Ss58Codec` implementation.",
+  "input": {
+    "public_key_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+    "prefix": 42
+  },
+  "expected_address": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+}

--- a/crates/signer-core/tests/corpora/extrinsic/call_data.json
+++ b/crates/signer-core/tests/corpora/extrinsic/call_data.json
@@ -1,0 +1,65 @@
+{
+  "description": "CladToken call data known-answer corpus (Phase 2). Wire format: [pallet_u8][call_u8][0x00 MultiAddress::Id][32-byte AccountId][optional SCALE Compact<u128> amount]. Pending Kotlin-oracle cross-check (deferred to Phase 2b). Pallet index 8, call indices 0–6 from audited constants in call.rs.",
+  "alice_account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+  "vectors": [
+    {
+      "call": "mint",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+        "amount": 1
+      },
+      "expected_bytes_hex": "080000d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d04"
+    },
+    {
+      "call": "mint",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+        "amount": 1000000
+      },
+      "expected_bytes_hex": "080000d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d02093d00"
+    },
+    {
+      "call": "transfer",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+        "amount": 1
+      },
+      "expected_bytes_hex": "080100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d04"
+    },
+    {
+      "call": "freeze",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+      },
+      "expected_bytes_hex": "080200d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+    },
+    {
+      "call": "unfreeze",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+      },
+      "expected_bytes_hex": "080300d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+    },
+    {
+      "call": "add_to_whitelist",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+      },
+      "expected_bytes_hex": "080400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+    },
+    {
+      "call": "remove_from_whitelist",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+      },
+      "expected_bytes_hex": "080500d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+    },
+    {
+      "call": "set_admin",
+      "args": {
+        "account_hex": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+      },
+      "expected_bytes_hex": "080600d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+    }
+  ]
+}

--- a/crates/signer-core/tests/crypto_known_answer.rs
+++ b/crates/signer-core/tests/crypto_known_answer.rs
@@ -1,0 +1,111 @@
+//! Known-answer tests for the crypto module.
+//!
+//! SS58 and Blake2b vectors come from `tests/corpora/crypto/`. ED25519 is
+//! tested as a sign→verify roundtrip (RFC 8032 deterministic; no OS RNG
+//! needed). SR25519 sign+verify roundtrip lives in the library unit tests
+//! (`src/crypto/sr25519.rs`) using `sign_deterministic`, keeping the
+//! randomized `sign` path out of integration tests per the agreed design.
+//! Byte-stable KAT vectors for both algorithms are in `crypto_kotlin_oracle.rs`
+//! (ignored, pending Phase 2b Kotlin oracle extraction).
+
+use signer_core::{blake2, ed25519, ss58};
+use std::path::Path;
+
+fn corpora_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpora/crypto")
+}
+
+// ── SS58 encode corpus ────────────────────────────────────────────────────────
+
+#[test]
+fn ss58_encode_corpus() {
+    let path = corpora_dir().join("ss58_encode.json");
+    let raw = std::fs::read_to_string(&path).expect("ss58_encode.json missing");
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("parse ss58_encode.json");
+
+    let pk_hex = v["input"]["public_key_hex"].as_str().unwrap();
+    let prefix = v["input"]["prefix"].as_u64().unwrap() as u16;
+    let expected_address = v["expected_address"].as_str().unwrap();
+
+    let pk = hex::decode(pk_hex).expect("bad public_key_hex");
+    let addr = ss58::encode(&pk, prefix).expect("ss58::encode failed");
+    assert_eq!(addr, expected_address, "SS58 encode mismatch");
+}
+
+// ── SS58 decode corpus ────────────────────────────────────────────────────────
+
+#[test]
+fn ss58_decode_corpus() {
+    let path = corpora_dir().join("ss58_decode.json");
+    let raw = std::fs::read_to_string(&path).expect("ss58_decode.json missing");
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("parse ss58_decode.json");
+
+    let address = v["input"]["address"].as_str().unwrap();
+    let expected_pk_hex = v["expected_public_key_hex"].as_str().unwrap();
+    let expected_prefix = v["expected_prefix"].as_u64().unwrap() as u16;
+
+    let (pk, prefix) = ss58::decode(address).expect("ss58::decode failed");
+    let got_hex = hex::encode(&pk);
+    assert_eq!(got_hex, expected_pk_hex, "SS58 decode pubkey mismatch");
+    assert_eq!(prefix, expected_prefix, "SS58 decode prefix mismatch");
+}
+
+// ── SS58 roundtrip property test ──────────────────────────────────────────────
+
+#[test]
+fn ss58_encode_decode_roundtrip() {
+    // Arbitrary 32-byte key; any prefix in 0..=16383.
+    let key: [u8; 32] = *b"test key for ss58 roundtrip!!!!\0";
+    for prefix in [0u16, 42, 1337] {
+        let addr = ss58::encode(&key, prefix).expect("encode");
+        let (decoded_key, decoded_prefix) = ss58::decode(&addr).expect("decode");
+        assert_eq!(&decoded_key, &key, "key roundtrip failed for prefix {prefix}");
+        assert_eq!(decoded_prefix, prefix, "prefix roundtrip failed for prefix {prefix}");
+    }
+}
+
+// ── Blake2b-256 corpus ────────────────────────────────────────────────────────
+
+#[test]
+fn blake2b_256_corpus() {
+    let path = corpora_dir().join("blake2b_256.json");
+    let raw = std::fs::read_to_string(&path).expect("blake2b_256.json missing");
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("parse blake2b_256.json");
+
+    for vector in v["vectors"].as_array().expect("vectors array missing") {
+        let input_hex = vector["input_hex"].as_str().unwrap();
+        let expected_hex = vector["expected_hash_hex"].as_str().unwrap();
+
+        let input = if input_hex.is_empty() { vec![] } else { hex::decode(input_hex).unwrap() };
+        let got = blake2::blake2b_256(&input);
+        assert_eq!(
+            hex::encode(&got),
+            expected_hex,
+            "blake2b_256 mismatch for vector: {}",
+            vector["description"].as_str().unwrap_or("?")
+        );
+    }
+}
+
+// ── ED25519 sign + verify roundtrip ──────────────────────────────────────────
+// ED25519 (RFC 8032) is deterministic — no OS RNG needed.
+// SR25519 roundtrip lives in library unit tests (src/crypto/sr25519.rs)
+// using sign_deterministic, keeping the randomized sign path out of here.
+
+#[test]
+fn ed25519_sign_verify_roundtrip() {
+    let seed = [0x37u8; 32];
+    let message = b"clad-sovereign phase-2 ed25519 roundtrip";
+
+    let sig = ed25519::sign(message, &seed).expect("ed25519::sign failed");
+    assert_eq!(sig.len(), 64, "signature must be 64 bytes");
+
+    let pubkey = ed25519::public_key_from_seed(&seed).expect("public_key_from_seed failed");
+    assert_eq!(pubkey.len(), 32, "public key must be 32 bytes");
+
+    assert!(
+        ed25519::verify(message, &sig, &pubkey),
+        "ed25519::verify failed for freshly signed message"
+    );
+    assert!(!ed25519::verify(b"wrong message", &sig, &pubkey), "verify must reject wrong message");
+}

--- a/crates/signer-core/tests/crypto_kotlin_oracle.rs
+++ b/crates/signer-core/tests/crypto_kotlin_oracle.rs
@@ -1,0 +1,61 @@
+//! Kotlin-oracle byte-stable KAT tests for crypto primitives.
+//!
+//! These tests verify that the Rust crypto output is byte-identical to the
+//! Kotlin oracle (`Signer.kt`, `Hasher.kt`, `Ss58.kt`).
+//!
+//! **Status**: All tests are `#[ignore]`d pending Phase 2b work:
+//! - Kotlin oracle JSON extraction script (`UosCryptoCorpusExport.kt`)
+//! - SR25519/ED25519 deterministic test-vector generation
+//! - Corpus files in `tests/corpora/crypto/`
+//!
+//! See: `docs/restructure-roadmap.md` § Deferred / discovered work.
+
+// ── SR25519 byte-stable KAT ───────────────────────────────────────────────────
+
+#[test]
+#[ignore = "Phase 2b: requires Kotlin oracle corpus (UosCryptoCorpusExport.kt)"]
+fn sr25519_kotlin_oracle_kat() {
+    // When implemented: read tests/corpora/crypto/sr25519_sign.json,
+    // call sr25519::sign_deterministic (test-only) per vector, assert byte equality.
+    todo!("Phase 2b")
+}
+
+#[test]
+#[ignore = "Phase 2b: requires Kotlin oracle corpus"]
+fn sr25519_verify_kotlin_oracle_kat() {
+    // When implemented: read tests/corpora/crypto/sr25519_verify.json,
+    // call sr25519::verify per vector, assert all return true.
+    todo!("Phase 2b")
+}
+
+// ── ED25519 byte-stable KAT ───────────────────────────────────────────────────
+
+#[test]
+#[ignore = "Phase 2b: requires Kotlin oracle corpus (UosCryptoCorpusExport.kt)"]
+fn ed25519_kotlin_oracle_kat() {
+    // When implemented: read tests/corpora/crypto/ed25519_sign.json,
+    // call ed25519::sign per vector (deterministic), assert byte equality.
+    todo!("Phase 2b")
+}
+
+#[test]
+#[ignore = "Phase 2b: requires Kotlin oracle corpus"]
+fn ed25519_verify_kotlin_oracle_kat() {
+    todo!("Phase 2b")
+}
+
+// ── Blake2b byte-stable KAT ───────────────────────────────────────────────────
+
+#[test]
+#[ignore = "Phase 2b: requires Kotlin oracle corpus (Hasher.kt output)"]
+fn blake2b_256_kotlin_oracle_kat() {
+    // When implemented: read tests/corpora/crypto/blake2b_256_oracle.json,
+    // call blake2::blake2b_256 per vector, assert byte equality.
+    todo!("Phase 2b")
+}
+
+#[test]
+#[ignore = "Phase 2b: requires Kotlin oracle corpus (Hasher.kt output)"]
+fn blake2b_512_kotlin_oracle_kat() {
+    todo!("Phase 2b")
+}

--- a/crates/signer-core/tests/extrinsic_call_data.rs
+++ b/crates/signer-core/tests/extrinsic_call_data.rs
@@ -1,0 +1,78 @@
+//! Known-answer tests for SCALE-encoded call data.
+//!
+//! Reads `tests/corpora/extrinsic/call_data.json` and verifies that the Rust
+//! builder produces byte-identical output to the expected vectors.
+//!
+//! The corpus was computed from audited pallet/call constants in `call.rs` and
+//! the SCALE wire-format rules documented in `call.rs` module doc.  Pending
+//! Kotlin-oracle cross-check (Phase 2b).
+
+use signer_core::extrinsic::{call, metadata};
+
+fn corpus_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpora/extrinsic/call_data.json")
+}
+
+/// Load and parse the call_data corpus, then verify each vector.
+#[test]
+fn call_data_corpus() {
+    let raw = std::fs::read_to_string(corpus_path()).expect("call_data.json missing");
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("parse call_data.json");
+
+    let vectors = v["vectors"].as_array().expect("vectors array missing");
+    assert!(!vectors.is_empty(), "corpus must have at least one vector");
+
+    for vec in vectors {
+        let call_name = vec["call"].as_str().unwrap();
+        let args_v = &vec["args"];
+        let expected_hex = vec["expected_bytes_hex"].as_str().unwrap();
+
+        let account_hex = args_v["account_hex"].as_str().unwrap();
+        let account = hex::decode(account_hex).expect("bad account_hex");
+        assert_eq!(account.len(), 32, "AccountId must be 32 bytes");
+
+        let args: Vec<Vec<u8>> = if let Some(amount) = args_v["amount"].as_u64() {
+            // Pack amount as raw LE u128 (16 bytes) as expected by metadata::build_call_data.
+            let amount_bytes = (amount as u128).to_le_bytes().to_vec();
+            vec![account, amount_bytes]
+        } else {
+            vec![account]
+        };
+
+        let got = metadata::build_call_data("CladToken", call_name, &args)
+            .unwrap_or_else(|e| panic!("build_call_data({call_name}) failed: {e:?}"));
+        assert_eq!(hex::encode(&got), expected_hex, "call_data mismatch for call '{call_name}'");
+    }
+}
+
+// ── Direct builder tests (complement to corpus) ───────────────────────────────
+
+#[test]
+fn mint_builder_matches_corpus_vector() {
+    let alice =
+        hex::decode("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").unwrap();
+    let got = call::mint(&alice, 1);
+    assert_eq!(
+        hex::encode(&got),
+        "080000d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d04"
+    );
+}
+
+#[test]
+fn freeze_builder_matches_corpus_vector() {
+    let alice =
+        hex::decode("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").unwrap();
+    let got = call::freeze(&alice);
+    assert_eq!(
+        hex::encode(&got),
+        "080200d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+    );
+}
+
+#[test]
+fn sort_signatories_is_lexicographic() {
+    let mut sigs: Vec<Vec<u8>> = vec![vec![0xFF; 32], vec![0x00; 32], vec![0x80; 32]];
+    call::sort_signatories(&mut sigs);
+    assert_eq!(sigs[0], vec![0x00u8; 32]);
+    assert_eq!(sigs[2], vec![0xFFu8; 32]);
+}

--- a/crates/signer-core/tests/extrinsic_metadata.rs
+++ b/crates/signer-core/tests/extrinsic_metadata.rs
@@ -1,0 +1,79 @@
+//! Tests for `metadata.rs`: pallet/call index validation and dispatch.
+//!
+//! Verifies that the hardcoded indices in `KNOWN_PALLETS` and
+//! `validate_known_call_indices` match the audited constants in `call.rs`,
+//! and that `build_call_data` correctly dispatches all known calls.
+
+use signer_core::extrinsic::metadata::{
+    build_call_data, validate_known_call_indices, KNOWN_PALLETS,
+};
+
+// ── KNOWN_PALLETS index check ─────────────────────────────────────────────────
+
+#[test]
+fn clad_token_pallet_index_is_8() {
+    let idx = KNOWN_PALLETS.iter().find(|(n, _)| *n == "CladToken").map(|(_, i)| *i);
+    assert_eq!(idx, Some(8), "CladToken must be pallet index 8");
+}
+
+#[test]
+fn multisig_pallet_index_is_7() {
+    let idx = KNOWN_PALLETS.iter().find(|(n, _)| *n == "Multisig").map(|(_, i)| *i);
+    assert_eq!(idx, Some(7), "Multisig must be pallet index 7");
+}
+
+// ── validate_known_call_indices ───────────────────────────────────────────────
+
+#[test]
+fn clad_token_call_indices_are_correct() {
+    let cases = [
+        ("mint", 0u8),
+        ("transfer", 1),
+        ("freeze", 2),
+        ("unfreeze", 3),
+        ("add_to_whitelist", 4),
+        ("remove_from_whitelist", 5),
+        ("set_admin", 6),
+    ];
+    for (call, expected_call_idx) in &cases {
+        let (pallet_idx, call_idx) =
+            validate_known_call_indices("CladToken", call).unwrap_or_else(|| {
+                panic!("validate_known_call_indices returned None for CladToken::{call}")
+            });
+        assert_eq!(pallet_idx, 8, "CladToken::{call} pallet index must be 8");
+        assert_eq!(call_idx, *expected_call_idx, "CladToken::{call} call index mismatch");
+    }
+}
+
+#[test]
+fn unknown_pallet_returns_none() {
+    assert!(validate_known_call_indices("UnknownPallet", "someCall").is_none());
+}
+
+#[test]
+fn unknown_call_returns_none() {
+    assert!(validate_known_call_indices("CladToken", "nonExistentCall").is_none());
+}
+
+// ── build_call_data dispatch errors ──────────────────────────────────────────
+
+#[test]
+fn build_call_data_unknown_pallet_returns_error() {
+    let result = build_call_data("BadPallet", "mint", &[]);
+    assert!(result.is_err(), "unknown pallet must return Err");
+}
+
+#[test]
+fn build_call_data_unknown_call_returns_error() {
+    let account = vec![0u8; 32];
+    let result = build_call_data("CladToken", "nonExistentCall", &[account]);
+    assert!(result.is_err(), "unknown call must return Err");
+}
+
+#[test]
+fn build_call_data_mint_missing_amount_returns_error() {
+    let account = vec![0u8; 32];
+    // Only 1 arg (account); mint requires amount as args[1].
+    let result = build_call_data("CladToken", "mint", &[account]);
+    assert!(result.is_err(), "mint with missing amount must return Err");
+}

--- a/crates/signer-core/tests/extrinsic_signed.rs
+++ b/crates/signer-core/tests/extrinsic_signed.rs
@@ -1,0 +1,29 @@
+//! Known-answer tests for `build_signed_extrinsic` and `complete_with_signature`.
+//!
+//! **Status**: Stubs — pending Phase 2b.
+//!
+//! Full KAT vectors require a live `clad-node --dev` instance to record:
+//!   - genesis hash, spec/tx version, nonce
+//!   - A reference SR25519 signing key and the resulting on-chain extrinsic hash
+//!
+//! Those are captured by the `roundtrip-node` feature and deferred to Phase 2b.
+//!
+//! See: `docs/restructure-roadmap.md` § Deferred / discovered work.
+
+#[test]
+#[ignore = "Phase 2b: requires live clad-node corpus for exact extrinsic bytes"]
+fn signed_extrinsic_kotlin_oracle_kat() {
+    todo!("Phase 2b")
+}
+
+#[test]
+#[ignore = "Phase 2b: requires live clad-node corpus"]
+fn complete_with_signature_kotlin_oracle_kat() {
+    todo!("Phase 2b")
+}
+
+#[test]
+#[ignore = "Phase 2b: roundtrip-node feature — submit to dev node and verify acceptance"]
+fn signed_extrinsic_roundtrip_against_node() {
+    todo!("Phase 2b")
+}

--- a/crates/signer-core/tests/extrinsic_signing_payload.rs
+++ b/crates/signer-core/tests/extrinsic_signing_payload.rs
@@ -1,0 +1,55 @@
+//! Known-answer tests for `build_signing_payload`.
+//!
+//! **Status**: Stubs — pending Phase 2b.
+//!
+//! The signing payload is the concatenation of:
+//!   `call_data || encoded_extra || encoded_additional`
+//! Blake2b-256 is applied when the payload is ≥ 256 bytes.
+//!
+//! Full KAT vectors require a live `clad-node --dev` instance to capture the
+//! genesis hash and spec/tx versions; those are deferred to Phase 2b along
+//! with the roundtrip-node feature.
+//!
+//! See: `docs/restructure-roadmap.md` § Deferred / discovered work.
+
+use signer_core::extrinsic::{call, payload, signed_extensions};
+
+/// Smoke test: payload for a trivial immortal transfer does not panic and is
+/// non-empty. Does not assert exact bytes (those require node corpus).
+#[test]
+fn build_signing_payload_immortal_smoke() {
+    let alice = [
+        0xd4u8, 0x35, 0x93, 0xc7, 0x15, 0xfd, 0xd3, 0x1c, 0x61, 0x14, 0x1a, 0xbd, 0x04, 0xa9, 0x9f,
+        0xd6, 0x82, 0x2c, 0x85, 0x58, 0x85, 0x4c, 0xcd, 0xe3, 0x9a, 0x56, 0x84, 0xe7, 0xa5, 0x6d,
+        0xa2, 0x7d,
+    ];
+    let call_data = call::transfer(&alice, 1);
+
+    let extra = signed_extensions::SignedExtra {
+        era_period: 0, // Immortal
+        era_phase: 0,
+        nonce: 0,
+        tip: 0,
+    };
+    let chain = signed_extensions::ChainInfo {
+        genesis_hash: vec![0u8; 32],
+        block_hash: vec![0u8; 32],
+        spec_version: 1,
+        tx_version: 1,
+    };
+
+    let p = payload::build_signing_payload(&call_data, &extra, &chain);
+    assert!(!p.is_empty(), "signing payload must not be empty");
+}
+
+#[test]
+#[ignore = "Phase 2b: requires live clad-node corpus (genesis_hash, spec_version, tx_version)"]
+fn build_signing_payload_kotlin_oracle_kat() {
+    todo!("Phase 2b")
+}
+
+#[test]
+#[ignore = "Phase 2b: requires large-payload Blake2b truncation corpus"]
+fn build_signing_payload_large_payload_is_hashed() {
+    todo!("Phase 2b")
+}


### PR DESCRIPTION
## Summary

- Implements ADR-007 Phase 2: Rust `signer-core` now contains all crypto and extrinsic-construction primitives previously handled by the Kotlin Multiplatform shared module
- SR25519/ED25519 signing, Blake2b hashing, SS58 encoding, and SCALE-encoded Substrate extrinsics (CladToken pallet 8 + Multisig pallet 7)
- UniFFI 0.28 surface extended with `CryptoError`, `ChainInfo`, `SignedExtra`, `SignedExtrinsic`, and all Phase 2 free functions
- 5 corpus JSON files + 6 integration test files; Kotlin oracle KAT vectors and roundtrip-node CI deferred to Phase 2b (documented in roadmap)

## What's in scope

**`src/crypto/`**
- `sr25519`: sign/verify/public_key_from_seed via schnorrkel 0.11 (Ed25519 expansion mode, `b"substrate"` signing context)
- `ed25519`: sign/verify/public_key_from_seed via ed25519-zebra 4
- `blake2`: blake2b_256/512/128 via blake2 0.10
- `ss58`: encode/decode with BLAKE2b-512 checksum, Substrate single/double-byte prefix encoding

**`src/extrinsic/`**
- `era`: Immortal/Mortal SCALE encoding matching `sp_runtime::generic::Era` exactly (including quantize_factor)
- `call`: CladToken calls 0–6 + Multisig as_multi/approve_as_multi/cancel_as_multi with SCALE wire format
- `call/scale`: hand-rolled `Compact<u64>`, `Compact<u128>`, `Compact<usize>`
- `signed_extensions`: `SignedExtra` + `ChainInfo`; era/nonce/tip SCALE encoding
- `payload`: `build_signing_payload` with Blake2b-256 truncation for payloads ≥ 256 bytes
- `signed`: `build_signed_extrinsic` / `complete_with_signature`
- `metadata`: `build_call_data` dispatch (hand-rolled; subxt-core deferred to Phase 2b)

**Notable constraints resolved:**
- UniFFI 0.28 does not support `u128` — `tip` is `u64` at the FFI boundary, zero-extended to `u128` for `Compact<u128>` encoding
- schnorrkel's internal nonce derivation calls `OsRng` even for the "deterministic" signing path (merlin `witness_rng` design); `schnorrkel/std` added to dev-dependencies for test builds only

## What's deferred (Phase 2b)

- `subxt-core` metadata-aware call encoding
- Kotlin oracle KAT vector extraction (`UosCryptoCorpusExport.kt`) for byte-stable SR25519/ED25519 fixtures
- `roundtrip-node` Cargo feature + CI job (requires live `clad-node --dev`)
- SCALE metadata corpus regeneration script

All deferred items are documented in `docs/restructure-roadmap.md` § Phase 2b.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -p signer-core --all-targets --locked -- -D warnings` passes (0 warnings)
- [x] `cargo test -p signer-core --locked` passes (43 tests pass, 11 ignored pending Phase 2b)
- [x] SS58 Alice vector cross-checked against polkadot-js (`5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY`)
- [x] Era encoding cross-checked against `sp_runtime::generic::Era` wire format (`period=64, phase=32` → `[0x05, 0x02]`)
- [x] CladToken call data vectors verified against audited pallet/call constants