### PR TITLE
chore(signer-core): upgrade uniffi from 0.28.3 to 0.29.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,43 +521,44 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "askama"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
  "askama_derive",
- "askama_escape",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash 2.1.1",
  "serde",
+ "serde_derive",
  "syn 2.0.110",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "askama_parser"
-version = "0.2.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
 ]
 
 [[package]]
@@ -895,15 +896,6 @@ dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1254,6 +1246,20 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5689,16 +5695,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -11296,7 +11292,7 @@ version = "29.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2509-2#7304752b47858f2cd601b35d0eb734ad4ccbbc48"
 dependencies = [
  "build-helper",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "console",
  "filetime",
  "jobserver",
@@ -12279,12 +12275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12319,48 +12309,52 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.28.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
 dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "fs-err",
  "glob",
  "goblin",
  "heck 0.5.0",
+ "indexmap",
  "once_cell",
- "paste",
  "serde",
+ "tempfile",
  "textwrap",
  "toml 0.5.11",
+ "uniffi_internal_macros",
  "uniffi_meta",
+ "uniffi_pipeline",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+checksum = "025a05cba02ee22b6624ac3d257e59c7395319ea8fe1aae33a7cdb4e2a3016cc"
 dependencies = [
  "anyhow",
  "camino",
@@ -12368,36 +12362,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_checksum_derive"
-version = "0.28.3"
+name = "uniffi_core"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
 dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
  "quote",
  "syn 2.0.110",
 ]
 
 [[package]]
-name = "uniffi_core"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
-dependencies = [
- "anyhow",
- "bytes",
- "log",
- "once_cell",
- "paste",
- "static_assertions",
-]
-
-[[package]]
 name = "uniffi_macros"
-version = "0.28.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
 dependencies = [
- "bincode",
  "camino",
  "fs-err",
  "once_cell",
@@ -12411,39 +12405,38 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
 dependencies = [
  "anyhow",
- "bytes",
  "siphasher 0.3.11",
- "uniffi_checksum_derive",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
-name = "uniffi_testing"
-version = "0.28.3"
+name = "uniffi_pipeline"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
 dependencies = [
  "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "once_cell",
+ "heck 0.5.0",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
- "uniffi_testing",
  "weedle2",
 ]
 

--- a/crates/signer-core/BUILD.md
+++ b/crates/signer-core/BUILD.md
@@ -19,7 +19,7 @@ Related documents:
 | Tool | Version | Where pinned |
 |------|---------|--------------|
 | Rust | 1.88.0 | `clad-studio/rust-toolchain.toml` |
-| UniFFI | 0.28.3 | `crates/signer-core/Cargo.toml` |
+| UniFFI | 0.29.5 | `crates/signer-core/Cargo.toml` |
 | Xcode | 16.4 | `.github/workflows/signer-core.yml` (macos-14 runner) |
 | Gradle | 8.14.3 | `crates/signer-core/android/gradle/wrapper/gradle-wrapper.properties` |
 | JDK | 17 | `crates/signer-core/android/sample/build.gradle.kts` (toolchain block) |
@@ -171,11 +171,6 @@ is a reproducibility bug; fix the script, not the workflow.
 
 ## Troubleshooting
 
-**Clippy fails with `empty_line_after_doc_comments` on generated code.**
-The UniFFI 0.28 scaffolding generator emits doc comments followed by a blank
-line on top-level constants. `#![allow(clippy::empty_line_after_doc_comments)]`
-in `src/lib.rs` suppresses this. Remove once UniFFI is upgraded past the fix.
-
 **JVM test fails with `UnsatisfiedLinkError`.**
 The host shared library must be staged at `build/android-host/`. Run
 `./build-android.sh` before `./gradlew :sample:test`. If the error mentions
@@ -244,5 +239,6 @@ See `tests/corpora/README.md` for the full workflow.
 - `account_introduction` URL encoding matches Java's `URLEncoder.encode`
   (`application/x-www-form-urlencoded`): spaces → `+`, unreserved set includes
   `*`.  This differs from RFC 3986; see `tests/corpora/README.md` for details.
-- UniFFI upgrade (past 0.28.3) is deferred to Phase 3 prep to avoid
-  binding-format drift before the mobile wiring lands.
+- UniFFI upgrade resolved: bumped to 0.29.5 in Sprint A1 (Phase 3).
+  `#![allow(clippy::empty_line_after_doc_comments)]` removed — the 0.29.x
+  scaffolding generator no longer emits the offending pattern.

--- a/crates/signer-core/Cargo.toml
+++ b/crates/signer-core/Cargo.toml
@@ -42,7 +42,7 @@ std = [
 ]
 
 [dependencies]
-uniffi = { version = "0.28.3" }
+uniffi = { version = "0.29.5" }
 thiserror = "1"
 schnorrkel = { version = "0.11", default-features = false, features = ["alloc"] }
 ed25519-zebra = { version = "4", default-features = false }
@@ -53,7 +53,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [build-dependencies]
-uniffi = { version = "0.28.3", features = ["build"] }
+uniffi = { version = "0.29.5", features = ["build"] }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/signer-core/src/lib.rs
+++ b/crates/signer-core/src/lib.rs
@@ -14,17 +14,9 @@
 //!
 //! The `crypto` and `extrinsic` modules are written using `alloc::` types
 //! exclusively and are no_std-compatible in isolation (ADR-007 Phase-2 NFC
-//! requirement).  The crate itself links std because UniFFI 0.28 scaffolding
+//! requirement).  The crate itself links std because UniFFI scaffolding
 //! generates `std`-using code; a std-free firmware build would exclude the
 //! UniFFI surface and depend on `signer-core` as a library crate directly.
-
-// `empty_line_after_doc_comments` is suppressed at crate level because the
-// UniFFI 0.28 scaffolding generator (invoked below via `include_scaffolding!`)
-// emits `///`-style doc comments followed by a blank line on top-level
-// constants — a pattern newer clippy rejects but which we cannot modify
-// without forking the generator. Tracked for removal after UniFFI upgrade
-// (deferred to Phase 3 prep per the restructure roadmap).
-#![allow(clippy::empty_line_after_doc_comments)]
 
 // `alloc` is explicitly declared so the `crypto` and `extrinsic` modules can
 // use `alloc::` paths, ensuring they stay compatible with no_std targets

--- a/crates/signer-core/src/signer_core.udl
+++ b/crates/signer-core/src/signer_core.udl
@@ -18,7 +18,7 @@
 // "Phase 2 preview, may evolve in Phase 3" — the FFI surface is conservative
 // (pure functions only, no interface objects) to minimise binding-format drift.
 //
-// UniFFI version: 0.28.3 (upgrade deferred to Phase 3 prep).
+// UniFFI version: 0.29.5 (upgraded in Sprint A1, Phase 3).
 
 // ── Error types ───────────────────────────────────────────────────────────────
 
@@ -62,7 +62,7 @@ dictionary ChainInfo {
 /// era_period == 0 means Immortal.  For mortal transactions set era_period to a
 /// power of 2 in the range 4–65536 and era_phase to current_block % era_period.
 ///
-/// tip is u64 (UniFFI 0.28 does not support u128 at the FFI boundary).
+/// tip is u64 (UniFFI does not support u128 at the FFI boundary).
 /// Practical tip values always fit in u64; the SCALE encoder zero-extends to
 /// Compact<u128> when building the signed extension bytes.
 dictionary SignedExtra {


### PR DESCRIPTION
## Summary

- Bumps `uniffi` in `crates/signer-core/Cargo.toml` (`[dependencies]` and `[build-dependencies]`) from **0.28.3** to **0.29.5** and regenerates `Cargo.lock`.
- No UDL grammar drift — `src/signer_core.udl` required no changes; the 0.29.x generator accepts the existing surface as-is.
- **`#![allow(clippy::empty_line_after_doc_comments)]` removed** from `src/lib.rs`: the 0.29.x scaffolding generator no longer emits the blank-line-after-doc-comment pattern that triggered the lint. The accompanying troubleshooting entry in `BUILD.md` (was lines 173–177) is also deleted.
- `BUILD.md` toolchain table (line 19) updated: `0.28.3` → `0.29.5`.
- `BUILD.md` UOS deferral note (was line 247) updated: marked the UniFFI upgrade resolved.
- `src/signer_core.udl` header comment updated to reflect the new version.

Closes: restructure-roadmap.md Phase 3 carry-over item "[Phase 1] Upgrade UniFFI past 0.28.3" (line 81).

## Affected files

| File | Change |
|------|--------|
| `crates/signer-core/Cargo.toml` | `uniffi 0.28.3` → `0.29.5` (deps + build-deps) |
| `Cargo.lock` | Regenerated for uniffi 0.29.5 sub-tree |
| `crates/signer-core/src/lib.rs` | Removed `#![allow(clippy::empty_line_after_doc_comments)]` |
| `crates/signer-core/src/signer_core.udl` | Updated version comment; removed stale "0.28" reference from `tip` doc |
| `crates/signer-core/BUILD.md` | Toolchain table + UOS deferral note updated |

## CI verification (all run locally before PR)

```
cargo fmt -- --check                                     PASS
cargo clippy -p signer-core --all-targets --locked       PASS  (no issues)
cargo test -p signer-core --locked                       PASS  (46 passed, 2 ignored)
./build-ios.sh                                           PASS  (xcframework built with 0.29.5)
xcodebuild test -scheme SignerCoreSample                 PASS  (** TEST SUCCEEDED **)
./build-android.sh                                       PASS  (Kotlin bindings + AAR generated)
./gradlew :sample:test                                   PASS  (PingTest PASSED, BUILD SUCCESSFUL)
```

## Clippy allow status

**Removable.** The `#![allow(clippy::empty_line_after_doc_comments)]` attribute is **not needed** with 0.29.5 — clippy passes cleanly without it. Attribute deleted.

## Scope

Sprint A1 only. No mobile-app changes, no Android library conversion (A2), no crypto corpus work (A3).