### PR TITLE
feat(signer-core): expose blake2b_128 via UniFFI

### DIFF
--- a/.github/workflows/signer-core.yml
+++ b/.github/workflows/signer-core.yml
@@ -142,7 +142,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Android — cross-compile per-ABI .so files via cargo-ndk, build the AAR,
-  # and run the instrumented test against an API-30 x86_64 emulator via
+  # and run the instrumented test against an API-33 x86_64 emulator via
   # reactivecircus/android-emulator-runner. KVM is available on ubuntu-latest.
   # ---------------------------------------------------------------------------
   android-aar:
@@ -203,21 +203,21 @@ jobs:
             ~/.gradle/wrapper
           key: signer-core-gradle-${{ hashFiles('crates/signer-core/android/**/*.gradle.kts', 'crates/signer-core/android/gradle/wrapper/gradle-wrapper.properties') }}
 
-      - name: Install Android emulator system image (API 30 x86_64)
+      - name: Install Android emulator system image (API 33 x86_64)
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
             "emulator" \
-            "system-images;android-30;default;x86_64" \
+            "system-images;android-33;default;x86_64" \
             "platforms;android-35" >/dev/null
 
       - name: Assemble Android instrumented-test APK
         working-directory: crates/signer-core/android
         run: ./gradlew :sample:assembleDebugAndroidTest --no-daemon
 
-      - name: Run instrumented tests on API-30 x86_64 emulator
+      - name: Run instrumented tests on API-33 x86_64 emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
+          api-level: 33
           arch: x86_64
           target: default
           disable-animations: true

--- a/crates/signer-core/android/sample/src/androidTest/kotlin/tech/wideas/clad/signer/sample/PingInstrumentedTest.kt
+++ b/crates/signer-core/android/sample/src/androidTest/kotlin/tech/wideas/clad/signer/sample/PingInstrumentedTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+import tech.wideas.clad.signer.blake2b128
 import tech.wideas.clad.signer.blake2b256
 import tech.wideas.clad.signer.ping
 
@@ -18,6 +19,8 @@ import tech.wideas.clad.signer.ping
  *  3. The Phase-2 blake2b256() crypto primitive is callable and produces the
  *     expected 32-byte digest, confirming the full Rust crypto stack is reachable
  *     at runtime — not just the greeting stub.
+ *  4. The Phase-4 blake2b128() crypto primitive is callable and produces the
+ *     expected 16-byte digest required for Substrate Blake2_128Concat storage keys.
  */
 @RunWith(AndroidJUnit4::class)
 class PingInstrumentedTest {
@@ -47,6 +50,29 @@ class PingInstrumentedTest {
         // Smoke-checks avalanche effect: single-bit difference changes the digest.
         val a = blake2b256(byteArrayOf(0x00))
         val b = blake2b256(byteArrayOf(0x01))
+        assertNotEquals(a.toList(), b.toList())
+    }
+
+    @Test
+    fun blake2b128ProducesSixteenBytesForFixedInput() {
+        // blake2b-128 always emits a 16-byte digest regardless of input length.
+        val input = "hello signer-core".toByteArray(Charsets.UTF_8)
+        val digest = blake2b128(input)
+        assertEquals(16, digest.size)
+    }
+
+    @Test
+    fun blake2b128IsDeterministic() {
+        // Same input must always yield the same digest — fundamental hash property.
+        val input = byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07)
+        assertArrayEquals(blake2b128(input), blake2b128(input))
+    }
+
+    @Test
+    fun blake2b128DifferentInputsProduceDifferentDigests() {
+        // Smoke-checks avalanche effect: single-bit difference changes the digest.
+        val a = blake2b128(byteArrayOf(0x00))
+        val b = blake2b128(byteArrayOf(0x01))
         assertNotEquals(a.toList(), b.toList())
     }
 }

--- a/crates/signer-core/src/lib.rs
+++ b/crates/signer-core/src/lib.rs
@@ -123,6 +123,13 @@ pub fn blake2b_256(data: Vec<u8>) -> Vec<u8> {
     blake2::blake2b_256(&data)
 }
 
+/// Compute a 16-byte Blake2b-128 hash of `data`.
+///
+/// Used for Substrate `Blake2_128Concat` storage key hashing.
+pub fn blake2b_128(data: Vec<u8>) -> Vec<u8> {
+    blake2::blake2b_128(&data)
+}
+
 // ── Phase 2: Extrinsic free functions ────────────────────────────────────────
 
 /// Build SCALE-encoded call data by pallet + call name with pre-encoded args.

--- a/crates/signer-core/src/signer_core.udl
+++ b/crates/signer-core/src/signer_core.udl
@@ -180,6 +180,8 @@ namespace signer_core {
 
     bytes blake2b_256(bytes data);
 
+    bytes blake2b_128(bytes data);
+
     // ── Phase 2: extrinsic ────────────────────────────────────────────────
     [Throws=CryptoError]
     bytes build_call_data(string pallet_name, string call_name, sequence<bytes> args);

--- a/crates/signer-core/tests/crypto_known_answer.rs
+++ b/crates/signer-core/tests/crypto_known_answer.rs
@@ -86,6 +86,31 @@ fn blake2b_256_corpus() {
     }
 }
 
+// ── Blake2b-128 known-answer vectors ─────────────────────────────────────────
+// Vectors verified against Python hashlib.blake2b(digest_size=16) and the
+// Kotlin Hasher.blake2b128 implementation (both follow the BLAKE2 spec).
+// Used for Substrate Blake2_128Concat storage key hashing.
+
+#[test]
+fn blake2b_128_kat() {
+    let cases: &[(&[u8], &str)] = &[
+        (b"", "cae66941d9efbd404e4d88758ea67670"),
+        (b"abc", "cf4ab791c62b8d2b2109c90275287816"),
+        (&[0u8; 32], "ff0f22492f44bac4c4b30ae58d0e8daa"),
+        (b"Substrate", "f3edea9bdc6ed3c0a83d84038b853a54"),
+    ];
+    for (input, expected) in cases {
+        let got = blake2::blake2b_128(input);
+        assert_eq!(got.len(), 16, "output must be 16 bytes");
+        assert_eq!(
+            hex::encode(&got),
+            *expected,
+            "blake2b_128 mismatch for input len {}",
+            input.len()
+        );
+    }
+}
+
 // ── ED25519 sign + verify roundtrip ──────────────────────────────────────────
 // ED25519 (RFC 8032) is deterministic — no OS RNG needed.
 // SR25519 roundtrip lives in library unit tests (src/crypto/sr25519.rs)


### PR DESCRIPTION
## Summary

- Adds `blake2b_128` to the UniFFI surface (UDL declaration + public Rust wrapper)
- The 16-byte Blake2b implementation already existed in `src/crypto/blake2.rs` — this change exposes it via FFI
- Adds known-answer test vectors (verified against Python `hashlib.blake2b(digest_size=16)` and Kotlin `Hasher.blake2b128`)
- Generated Swift binding: `blake2b128(data: Data) -> Data`

## Why

Substrate `Blake2_128Concat` storage key hashing requires a 16-byte Blake2b digest. This function is needed by `Platform/Substrate/StorageKey.swift`, `BalanceService.swift`, and `SubstrateClient.swift` in clad-mobile Phase 4 Wave 1.B Phase B. Previously only `blake2b_256` was on the UniFFI surface.

Resolves **Blocker B1** from `clad-sovereign/CURRENT.md`.

## Dependency

`clad-mobile` PR for Phase B must be merged after this — it commits the rebuilt `SignerCore.xcframework` generated from this change.

## Test plan

- [x] `cargo test --locked` — 50 tests pass (was 49; new `blake2b_128_kat` added)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets --locked -- -D warnings` — no issues
- [x] `./build-ios.sh` — xcframework rebuilt successfully; `blake2b128(data:)` present in generated Swift bindings